### PR TITLE
feat: add deck list and detail

### DIFF
--- a/__tests__/decks.test.ts
+++ b/__tests__/decks.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { decks, getDeckBySlug } from "@/lib/decks";
+
+describe("decks library", () => {
+  it("loads deck seed", () => {
+    expect(decks.length).toBeGreaterThan(0);
+  });
+
+  it("finds deck by slug", () => {
+    const deck = getDeckBySlug(decks[0].slug);
+    expect(deck?.slug).toBe(decks[0].slug);
+  });
+});

--- a/src/app/decks/[slug]/page.tsx
+++ b/src/app/decks/[slug]/page.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { getDeckBySlug } from "@/lib/decks";
+import { getCardBySlug } from "@/lib/cards";
+
+type Props = {
+  params: { slug: string };
+};
+
+export default function DeckDetailPage({ params }: Props) {
+  const deck = getDeckBySlug(params.slug);
+
+  if (!deck) {
+    return (
+      <div className="min-h-screen bg-black text-white">
+        <main className="mx-auto max-w-3xl px-6 py-12">
+          <p className="text-sm text-zinc-400">덱을 찾을 수 없어요.</p>
+          <Link className="mt-6 inline-flex text-emerald-300" href="/decks">
+            ← 덱 목록으로
+          </Link>
+        </main>
+      </div>
+    );
+  }
+
+  const cards = deck.cards
+    .map((slug) => getCardBySlug(slug))
+    .filter(Boolean);
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      <main className="mx-auto max-w-4xl px-6 py-12">
+        <Link className="text-sm text-emerald-300" href="/decks">
+          ← 덱 목록으로
+        </Link>
+
+        <article className="mt-8 rounded-xl border border-zinc-800 bg-zinc-950 p-6">
+          <h1 className="text-2xl font-semibold">{deck.name}</h1>
+          {deck.description && (
+            <p className="mt-2 text-sm text-zinc-400">{deck.description}</p>
+          )}
+          <div className="mt-4 flex flex-wrap gap-2">
+            {deck.tags.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-zinc-800 px-2 py-0.5 text-[10px] text-zinc-400"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        </article>
+
+        <section className="mt-8 grid gap-4">
+          {cards.map((card) => (
+            <div
+              key={card?.slug}
+              className="rounded-xl border border-zinc-800 bg-zinc-950 p-4"
+            >
+              <div className="flex items-center justify-between text-xs text-zinc-500">
+                <span>{card?.character}</span>
+                <span className="uppercase">{card?.type}</span>
+              </div>
+              <Link
+                className="mt-2 inline-flex text-lg font-semibold hover:text-emerald-300"
+                href={`/cards/${card?.slug}`}
+              >
+                {card?.title}
+              </Link>
+            </div>
+          ))}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/decks/page.tsx
+++ b/src/app/decks/page.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import { decks } from "@/lib/decks";
+
+export default function DeckListPage() {
+  return (
+    <div className="min-h-screen bg-black text-white">
+      <main className="mx-auto max-w-5xl px-6 py-12">
+        <header className="mb-10">
+          <h1 className="text-3xl font-semibold">덱</h1>
+          <p className="mt-2 text-sm text-zinc-400">
+            카드로 묶은 플레이리스트
+          </p>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-2">
+          {decks.map((deck) => (
+            <article
+              key={deck.slug}
+              className="rounded-xl border border-zinc-800 bg-zinc-950 p-5"
+            >
+              <div className="flex items-center justify-between text-xs text-zinc-500">
+                <span>{deck.cards.length} cards</span>
+                <span className="uppercase">deck</span>
+              </div>
+              <h2 className="mt-3 text-lg font-semibold">
+                <Link className="hover:text-emerald-300" href={`/decks/${deck.slug}`}>
+                  {deck.name}
+                </Link>
+              </h2>
+              {deck.description && (
+                <p className="mt-2 text-sm text-zinc-400">
+                  {deck.description}
+                </p>
+              )}
+              <div className="mt-4 flex flex-wrap gap-2">
+                {deck.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full border border-zinc-800 px-2 py-0.5 text-[10px] text-zinc-400"
+                  >
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            </article>
+          ))}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,14 @@ export default function Home({ searchParams }: Props) {
           <p className="mt-2 text-sm text-zinc-400">
             보컬로이드 순간을 카드로 모으는 커뮤니티 아카이브
           </p>
+          <div className="mt-4 flex gap-4 text-sm">
+            <Link className="text-emerald-300" href="/decks">
+              덱 보기 →
+            </Link>
+            <Link className="text-emerald-300" href="/cards/new">
+              카드 작성 →
+            </Link>
+          </div>
         </header>
 
         <section className="mb-8">

--- a/src/data/decks.json
+++ b/src/data/decks.json
@@ -1,0 +1,16 @@
+[
+  {
+    "slug": "classic-miku",
+    "name": "Classic Miku",
+    "description": "초기 대표곡 모음",
+    "tags": ["classic", "miku"],
+    "cards": ["melt", "world-is-mine", "rolling-girl"]
+  },
+  {
+    "slug": "stage-hits",
+    "name": "Stage Hits",
+    "description": "라이브에서 많이 불린 곡",
+    "tags": ["iconic", "live"],
+    "cards": ["melt", "ievan-polkka", "reverse-rainbow"]
+  }
+]

--- a/src/lib/decks.ts
+++ b/src/lib/decks.ts
@@ -1,0 +1,14 @@
+import decksSeed from "@/data/decks.json";
+
+export type Deck = {
+  slug: string;
+  name: string;
+  description?: string;
+  tags: string[];
+  cards: string[];
+};
+
+export const decks = decksSeed as Deck[];
+
+export const getDeckBySlug = (slug: string) =>
+  decks.find((deck) => deck.slug === slug);


### PR DESCRIPTION
## 🎵 변경 사항\n- /decks 덱 리스트 페이지 추가\n- /decks/[slug] 덱 상세 페이지 추가\n- 덱 시드 데이터 및 조회 헬퍼 추가\n- 덱 유닛 테스트 추가\n\n## 🎹 테스트\n- pnpm test