### PR TITLE
feat: add deck edit ui

### DIFF
--- a/__tests__/deck-edit.test.ts
+++ b/__tests__/deck-edit.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildDeckUpdatePayload, validateDeckUpdatePayload } from "@/lib/deck-edit";
+
+const base = {
+  name: "Classic Miku",
+  description: "대표곡 모음",
+  tags: ["classic", "miku"],
+  cards: ["melt", "world-is-mine"],
+};
+
+describe("deck edit helpers", () => {
+  it("builds normalized payload", () => {
+    const payload = buildDeckUpdatePayload({
+      ...base,
+      name: "  Classic Miku  ",
+      tags: ["classic", "miku", ""],
+    });
+
+    expect(payload.name).toBe("Classic Miku");
+    expect(payload.tags).toEqual(["classic", "miku"]);
+  });
+
+  it("requires name and at least one card", () => {
+    expect(validateDeckUpdatePayload(buildDeckUpdatePayload(base))).toEqual([]);
+
+    expect(
+      validateDeckUpdatePayload(
+        buildDeckUpdatePayload({ ...base, name: "", cards: [] })
+      )
+    ).toEqual(["name", "cards"]);
+  });
+});

--- a/src/app/decks/[slug]/edit/page.tsx
+++ b/src/app/decks/[slug]/edit/page.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { cards as allCards } from "@/lib/cards";
+import { getDeckBySlug } from "@/lib/decks";
+import {
+  buildDeckUpdatePayload,
+  validateDeckUpdatePayload,
+} from "@/lib/deck-edit";
+
+export default function DeckEditPage({ params }: { params: { slug: string } }) {
+  const deck = getDeckBySlug(params.slug);
+
+  const [name, setName] = useState(deck?.name ?? "");
+  const [description, setDescription] = useState(deck?.description ?? "");
+  const [tags, setTags] = useState(deck?.tags ?? []);
+  const [selectedCards, setSelectedCards] = useState(deck?.cards ?? []);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [saved, setSaved] = useState(false);
+
+  const sortedCards = useMemo(
+    () => [...allCards].sort((a, b) => a.title.localeCompare(b.title)),
+    []
+  );
+
+  if (!deck) {
+    return (
+      <div className="min-h-screen bg-black text-white">
+        <main className="mx-auto max-w-3xl px-6 py-12">
+          <p className="text-sm text-[var(--terminal-muted)]">덱을 찾을 수 없어요.</p>
+          <Link className="mt-6 inline-flex text-[var(--terminal-fg)]" href="/decks">
+            ← 덱 목록으로
+          </Link>
+        </main>
+      </div>
+    );
+  }
+
+  const toggleCard = (slug: string) => {
+    setSelectedCards((prev) =>
+      prev.includes(slug) ? prev.filter((item) => item !== slug) : [...prev, slug]
+    );
+  };
+
+  const onSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const payload = buildDeckUpdatePayload({
+      name,
+      description,
+      tags,
+      cards: selectedCards,
+    });
+    const nextErrors = validateDeckUpdatePayload(payload);
+    setErrors(nextErrors);
+    setSaved(nextErrors.length === 0);
+  };
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      <main className="mx-auto max-w-4xl px-6 py-12">
+        <div className="flex items-center justify-between">
+          <Link className="text-sm text-[var(--terminal-fg)]" href={`/decks/${deck.slug}`}>
+            ← 덱 상세로
+          </Link>
+          <span className="text-xs text-[var(--terminal-muted)]">EDIT MODE</span>
+        </div>
+
+        <form onSubmit={onSubmit} className="mt-8 space-y-6 terminal-frame p-6">
+          <div className="space-y-2">
+            <label className="text-xs text-[var(--terminal-muted)]">덱 이름</label>
+            <input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="w-full border border-[var(--terminal-border)] bg-black px-3 py-2 text-sm text-[var(--terminal-fg)]"
+            />
+            {errors.includes("name") && (
+              <p className="text-xs text-[var(--terminal-error)]">덱 이름을 입력해줘.</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-xs text-[var(--terminal-muted)]">설명</label>
+            <textarea
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              className="min-h-[96px] w-full border border-[var(--terminal-border)] bg-black px-3 py-2 text-sm text-[var(--terminal-fg)]"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-xs text-[var(--terminal-muted)]">태그</label>
+            <div className="flex flex-wrap gap-2">
+              {allCards.flatMap((card) => card.tags).filter((tag, index, arr) => arr.indexOf(tag) === index).sort().map((tag) => {
+                const active = tags.includes(tag);
+                return (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() =>
+                      setTags((prev) =>
+                        active ? prev.filter((item) => item !== tag) : [...prev, tag]
+                      )
+                    }
+                    className={`border px-2 py-1 text-xs ${
+                      active
+                        ? "border-[var(--terminal-fg)] text-[var(--terminal-fg)]"
+                        : "border-[var(--terminal-border)] text-[var(--terminal-muted)]"
+                    }`}
+                  >
+                    #{tag}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-xs text-[var(--terminal-muted)]">카드 선택</label>
+              <span className="text-xs text-[var(--terminal-muted)]">{selectedCards.length}개 선택</span>
+            </div>
+            <div className="grid gap-2 md:grid-cols-2">
+              {sortedCards.map((card) => (
+                <label
+                  key={card.slug}
+                  className="flex items-center gap-3 border border-[var(--terminal-border)] bg-black px-3 py-2 text-sm"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedCards.includes(card.slug)}
+                    onChange={() => toggleCard(card.slug)}
+                    className="h-3 w-3 accent-emerald-400"
+                  />
+                  <span>{card.title}</span>
+                </label>
+              ))}
+            </div>
+            {errors.includes("cards") && (
+              <p className="text-xs text-[var(--terminal-error)]">카드를 최소 1개 선택해줘.</p>
+            )}
+          </div>
+
+          <button type="submit" className="terminal-button">
+            [ 저장 시뮬레이션 ]
+          </button>
+
+          {saved && (
+            <p className="text-xs text-[var(--terminal-fg)]">덱 편집 입력 값이 유효해요!</p>
+          )}
+        </form>
+      </main>
+    </div>
+  );
+}

--- a/src/app/decks/[slug]/page.tsx
+++ b/src/app/decks/[slug]/page.tsx
@@ -29,9 +29,14 @@ export default function DeckDetailPage({ params }: Props) {
   return (
     <div className="min-h-screen bg-black text-white">
       <main className="mx-auto max-w-4xl px-6 py-12">
-        <Link className="text-sm text-[var(--terminal-fg)]" href="/decks">
-          ← 덱 목록으로
-        </Link>
+        <div className="flex items-center justify-between gap-4">
+          <Link className="text-sm text-[var(--terminal-fg)]" href="/decks">
+            ← 덱 목록으로
+          </Link>
+          <Link className="terminal-button text-xs" href={`/decks/${deck.slug}/edit`}>
+            [ EDIT DECK ]
+          </Link>
+        </div>
 
         <article className="mt-8 terminal-frame p-6">
           <h1 className="text-2xl font-semibold">{deck.name}</h1>

--- a/src/lib/deck-edit.ts
+++ b/src/lib/deck-edit.ts
@@ -1,0 +1,22 @@
+export type DeckUpdateInput = {
+  name: string;
+  description?: string;
+  tags: string[];
+  cards: string[];
+};
+
+export const buildDeckUpdatePayload = (input: DeckUpdateInput) => ({
+  name: input.name.trim(),
+  description: input.description?.trim() || undefined,
+  tags: input.tags.map((tag) => tag.trim()).filter(Boolean),
+  cards: input.cards,
+});
+
+export const validateDeckUpdatePayload = (
+  payload: ReturnType<typeof buildDeckUpdatePayload>
+) => {
+  const errors: string[] = [];
+  if (!payload.name) errors.push("name");
+  if (payload.cards.length === 0) errors.push("cards");
+  return errors;
+};


### PR DESCRIPTION
## 🎵 변경 사항\n- 덱 상세에서 편집 페이지로 진입 링크 추가\n-  편집 UI 추가\n- 카드 추가/삭제 체크 UI 및 태그 토글 추가\n- 저장 시뮬레이션/유효성 헬퍼 추가\n- deck edit 테스트 추가\n\n## 🎹 테스트\n- pnpm test\n- pnpm typecheck\n- pnpm build