### PR TITLE
feat(archive): clarify Voxie value and enrich details 🎵

### DIFF
--- a/__tests__/cards.test.ts
+++ b/__tests__/cards.test.ts
@@ -1,19 +1,25 @@
 import { describe, expect, it } from "vitest";
-import { filterCards, listTags, cards } from "@/lib/cards";
+import { cards, getCardBySlug, getCardExternalLinks, searchCards } from "@/lib/cards";
 
-describe("cards library", () => {
-  it("lists all tags", () => {
-    const tags = listTags();
-    expect(tags.length).toBeGreaterThan(0);
-    expect(tags).toEqual([...tags].sort());
+describe("cards archive helpers", () => {
+  it("enriches seed cards with archive metadata", () => {
+    const card = getCardBySlug("rolling-girl", cards);
+
+    expect(card?.producer).toBe("wowaka");
+    expect(card?.summary).toContain("대표곡");
   });
 
-  it("filters cards by tag", () => {
-    const tag = cards[0].tags[0];
-    const filtered = filterCards(tag);
-    expect(filtered.length).toBeGreaterThan(0);
-    filtered.forEach((card) => {
-      expect(card.tags).toContain(tag);
-    });
+  it("builds deterministic external search links", () => {
+    const card = getCardBySlug("melt", cards);
+    expect(card).toBeDefined();
+
+    const links = getCardExternalLinks(card!);
+    expect(links.youtubeSearch).toContain("Melt%20Hatsune%20Miku");
+    expect(links.niconicoSearch).toContain("Melt%20Hatsune%20Miku");
+  });
+
+  it("matches producer names in search", () => {
+    const results = searchCards("wowaka", cards);
+    expect(results.map((card) => card.slug)).toContain("rolling-girl");
   });
 });

--- a/src/app/cards/[slug]/page.tsx
+++ b/src/app/cards/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
-import { getCardBySlugAsync } from "@/lib/cards";
+import { getCardBySlugAsync, getCardExternalLinks } from "@/lib/cards";
+import { listDecks } from "@/lib/decks";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -24,6 +25,10 @@ export default async function CardDetail({ params }: Props) {
     );
   }
 
+  const links = getCardExternalLinks(card);
+  const decks = await listDecks();
+  const relatedDecks = decks.filter((deck) => deck.cards.includes(card.slug));
+
   return (
     <div className="min-h-screen text-white">
       <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 sm:py-12">
@@ -34,12 +39,18 @@ export default async function CardDetail({ params }: Props) {
           </div>
           <div className="grid gap-6 px-5 py-6 sm:px-8 sm:py-8 md:grid-cols-[minmax(0,1fr)_280px]">
             <div>
-              <Link className="text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)] hover:text-[var(--terminal-fg)]" href="/">
+              <Link
+                className="text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)] hover:text-[var(--terminal-fg)]"
+                href="/"
+              >
                 ← return --cards
               </Link>
-              <h1 className="mt-4 text-3xl font-semibold uppercase tracking-[0.12em] sm:text-4xl">
-                {card.title}
-              </h1>
+              <h1 className="mt-4 text-3xl font-semibold sm:text-4xl">{card.title}</h1>
+              {card.summary && (
+                <p className="mt-4 max-w-2xl text-sm leading-7 text-[var(--terminal-soft)] sm:text-base">
+                  {card.summary}
+                </p>
+              )}
               <div className="mt-4 flex flex-wrap gap-2">
                 {card.tags.map((item) => (
                   <span key={item} className="terminal-chip">
@@ -55,33 +66,113 @@ export default async function CardDetail({ params }: Props) {
                   <span className="text-[var(--terminal-muted)]">character</span>
                   <span>{card.character}</span>
                 </div>
-                <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
-                  <span className="text-[var(--terminal-muted)]">type</span>
-                  <span>{card.type}</span>
-                </div>
-                <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
-                  <span className="text-[var(--terminal-muted)]">tags</span>
-                  <span>{card.tags.length}</span>
-                </div>
+                {card.producer && (
+                  <div className="flex items-center justify-between gap-4 border border-[var(--terminal-border)] px-3 py-2">
+                    <span className="text-[var(--terminal-muted)]">producer</span>
+                    <span className="text-right">{card.producer}</span>
+                  </div>
+                )}
+                {card.year && (
+                  <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
+                    <span className="text-[var(--terminal-muted)]">year</span>
+                    <span>{card.year}</span>
+                  </div>
+                )}
+                {card.era && (
+                  <div className="flex items-center justify-between gap-4 border border-[var(--terminal-border)] px-3 py-2">
+                    <span className="text-[var(--terminal-muted)]">era</span>
+                    <span className="text-right">{card.era}</span>
+                  </div>
+                )}
               </div>
             </aside>
           </div>
         </header>
 
-        <section className="mt-8 terminal-frame p-5 sm:p-6">
-          <div className="text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)]">source</div>
-          {card.source_url ? (
-            <a
-              href={card.source_url}
-              className="mt-4 inline-flex terminal-button text-xs"
-              target="_blank"
-              rel="noreferrer"
-            >
-              [ source --open ]
-            </a>
-          ) : (
-            <p className="mt-4 text-sm text-[var(--terminal-muted)]">등록된 출처 링크가 없어요.</p>
-          )}
+        <section className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <article className="terminal-frame p-5 sm:p-6">
+            <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">archive note</p>
+            {card.description ? (
+              <div className="mt-4 space-y-4 text-sm leading-7 text-[var(--terminal-soft)]">
+                {card.description.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-4 text-sm text-[var(--terminal-muted)]">아직 등록된 설명이 없어요.</p>
+            )}
+
+            {card.whyItMatters && (
+              <div className="mt-6 border border-[var(--terminal-border)] px-4 py-4">
+                <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">why this card matters</p>
+                <p className="mt-3 text-sm leading-7 text-[var(--terminal-fg)]">{card.whyItMatters}</p>
+              </div>
+            )}
+
+            <div className="mt-6">
+              <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">mood / usage</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {(card.mood ?? card.tags).map((item) => (
+                  <span key={item} className="terminal-chip" data-active="true">
+                    {item}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </article>
+
+          <aside className="space-y-6">
+            <section className="terminal-frame p-5">
+              <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">signal preview</p>
+              <div className="mt-4 flex aspect-[4/3] items-end border border-[var(--terminal-border)] bg-[radial-gradient(circle_at_top,rgba(57,197,187,0.28)_0%,rgba(8,17,29,0.95)_55%,rgba(3,5,13,1)_100%)] p-5">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-soft)]">{card.character}</p>
+                  <p className="mt-2 text-2xl font-semibold text-[var(--terminal-fg)]">{card.title}</p>
+                  <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">{card.summary}</p>
+                </div>
+              </div>
+            </section>
+
+            <section className="terminal-frame p-5">
+              <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">listen / reference</p>
+              <div className="mt-4 flex flex-col gap-3 text-sm">
+                {links.source && (
+                  <a href={links.source} target="_blank" rel="noreferrer" className="terminal-button text-center">
+                    [ reference source ]
+                  </a>
+                )}
+                <a href={links.youtubeSearch} target="_blank" rel="noreferrer" className="terminal-button text-center">
+                  [ search on youtube ]
+                </a>
+                <a href={links.niconicoSearch} target="_blank" rel="noreferrer" className="terminal-button text-center">
+                  [ search on niconico ]
+                </a>
+              </div>
+            </section>
+
+            <section className="terminal-frame p-5">
+              <div className="flex items-center justify-between gap-4">
+                <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">included in decks</p>
+                <Link href="/decks" className="text-xs text-[var(--terminal-fg)]">
+                  모든 덱 보기 →
+                </Link>
+              </div>
+              <div className="mt-4 space-y-3">
+                {relatedDecks.length > 0 ? (
+                  relatedDecks.map((deck) => (
+                    <Link key={deck.slug} href={`/decks/${deck.slug}`} className="block border border-[var(--terminal-border)] px-4 py-4">
+                      <p className="text-sm font-semibold">{deck.name}</p>
+                      <p className="mt-1 text-xs leading-6 text-[var(--terminal-muted)]">
+                        {deck.shortPitch ?? deck.description}
+                      </p>
+                    </Link>
+                  ))
+                ) : (
+                  <p className="text-sm text-[var(--terminal-muted)]">아직 이 카드를 담은 덱이 없어요.</p>
+                )}
+              </div>
+            </section>
+          </aside>
         </section>
       </main>
     </div>

--- a/src/app/decks/[slug]/page.tsx
+++ b/src/app/decks/[slug]/page.tsx
@@ -38,18 +38,19 @@ export default async function DeckDetailPage({ params }: Props) {
           <div className="grid gap-6 px-5 py-6 sm:px-8 sm:py-8 md:grid-cols-[minmax(0,1fr)_260px]">
             <div>
               <div className="flex flex-wrap items-center gap-3">
-                <Link className="text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)] hover:text-[var(--terminal-fg)]" href="/decks">
+                <Link
+                  className="text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)] hover:text-[var(--terminal-fg)]"
+                  href="/decks"
+                >
                   ← return --decks
                 </Link>
                 <Link className="terminal-button text-xs" href={`/decks/${deck.slug}/edit`}>
                   [ edit deck ]
                 </Link>
               </div>
-              <h1 className="mt-4 text-3xl font-semibold uppercase tracking-[0.12em] sm:text-4xl">
-                {deck.name}
-              </h1>
+              <h1 className="mt-4 text-3xl font-semibold sm:text-4xl">{deck.name}</h1>
               {deck.description && (
-                <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--terminal-muted)]">
+                <p className="mt-3 max-w-2xl text-sm leading-7 text-[var(--terminal-soft)]">
                   {deck.description}
                 </p>
               )}
@@ -72,24 +73,66 @@ export default async function DeckDetailPage({ params }: Props) {
                   <span className="text-[var(--terminal-muted)]">tags</span>
                   <span>{deck.tags.length}</span>
                 </div>
+                {deck.featured && (
+                  <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
+                    <span className="text-[var(--terminal-muted)]">featured</span>
+                    <span>yes</span>
+                  </div>
+                )}
               </div>
             </aside>
           </div>
         </header>
 
+        <section className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <article className="terminal-frame p-5 sm:p-6">
+            <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">why this deck exists</p>
+            <p className="mt-4 text-sm leading-7 text-[var(--terminal-fg)]">
+              {deck.shortPitch ?? "이 덱은 관련 카드들을 하나의 맥락으로 묶기 위한 큐레이션 단위예요."}
+            </p>
+
+            {deck.curatorNote && (
+              <div className="mt-6 border border-[var(--terminal-border)] px-4 py-4">
+                <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">curator note</p>
+                <p className="mt-3 text-sm leading-7 text-[var(--terminal-soft)]">{deck.curatorNote}</p>
+              </div>
+            )}
+          </article>
+
+          <aside className="terminal-frame p-5">
+            <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">deck preview</p>
+            <div className="mt-4 space-y-3">
+              {cards.slice(0, 3).map((card) => (
+                <div key={card?.slug} className="border border-[var(--terminal-border)] px-4 py-4">
+                  <p className="text-sm font-semibold text-[var(--terminal-fg)]">{card?.title}</p>
+                  <p className="mt-1 text-xs leading-6 text-[var(--terminal-muted)]">{card?.summary}</p>
+                </div>
+              ))}
+            </div>
+            <p className="mt-4 text-sm leading-7 text-[var(--terminal-muted)]">
+              덱은 단순히 카드를 모아두는 박스가 아니라, 시대·감정·프로듀서·무대 맥락을 함께 읽게 해주는 큐레이션 단위예요.
+            </p>
+          </aside>
+        </section>
+
         <section className="mt-8 grid gap-4">
           {cards.map((card) => (
-            <div key={card?.slug} className="terminal-frame p-4 sm:p-5">
+            <div key={card?.slug} className="terminal-frame p-5">
               <div className="flex items-center justify-between text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)]">
                 <span>{card?.character}</span>
                 <span>{card?.type}</span>
               </div>
-              <Link
-                className="mt-3 inline-flex text-lg font-semibold uppercase tracking-[0.08em] hover:text-[var(--terminal-fg)]"
-                href={`/cards/${card?.slug}`}
-              >
+              <Link className="mt-3 inline-flex text-lg font-semibold hover:text-[var(--terminal-fg)]" href={`/cards/${card?.slug}`}>
                 {card?.title}
               </Link>
+              {card?.summary && <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">{card.summary}</p>}
+              <div className="mt-3 flex flex-wrap gap-2">
+                {card?.tags.map((tag) => (
+                  <span key={tag} className="terminal-chip">
+                    #{tag}
+                  </span>
+                ))}
+              </div>
             </div>
           ))}
         </section>

--- a/src/app/decks/page.tsx
+++ b/src/app/decks/page.tsx
@@ -20,12 +20,10 @@ export default async function DeckListPage({
             <span>{decks.length.toString().padStart(2, "0")} results</span>
           </div>
           <div className="px-5 py-6 sm:px-8 sm:py-8">
-            <h1 className="text-3xl font-semibold uppercase tracking-[0.18em] sm:text-4xl">
-              Decks
-            </h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--terminal-muted)]">
-              카드로 묶은 플레이리스트를 미쿠 콘솔 스타일로 탐색해요. 차분한 딥네이비
-              배경 위에 블루그린 phosphor 하이라이트를 얹었어요.
+            <h1 className="text-3xl font-semibold sm:text-4xl">Decks</h1>
+            <p className="mt-3 max-w-2xl text-sm leading-7 text-[var(--terminal-soft)]">
+              카드들을 시대, 감정, 퍼포먼스 맥락으로 엮는 큐레이션 묶음이에요. 덱이 왜 존재하는지
+              바로 보이도록 설명과 예시를 함께 노출합니다.
             </p>
             <div className="mt-6 flex flex-wrap gap-3">
               <Link className="terminal-button" href="/decks/new">
@@ -49,7 +47,7 @@ export default async function DeckListPage({
                 type="text"
                 name="q"
                 defaultValue={query}
-                placeholder="search --decks"
+                placeholder="덱 이름, 설명, 태그 검색"
                 className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
               />
               <button type="submit" className="terminal-button sm:min-w-36">
@@ -65,12 +63,10 @@ export default async function DeckListPage({
               <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">
                 no decks loaded
               </p>
-              <h2 className="mt-3 text-2xl font-semibold uppercase tracking-[0.12em]">
-                아직 덱이 없어요
-              </h2>
+              <h2 className="mt-3 text-2xl font-semibold">아직 덱이 없어요</h2>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--terminal-muted)]">
-                첫 플레이리스트를 만들면 카드들을 테마별로 묶어 볼 수 있어요. 미쿠 콘솔의
-                다음 패널은 덱 생성 화면이에요.
+                첫 플레이리스트를 만들면 카드들을 테마별로 묶어 볼 수 있어요. 미쿠 콘솔의 다음 패널은
+                덱 생성 화면이에요.
               </p>
               <div className="mt-6">
                 <Link className="terminal-button" href="/decks/new">
@@ -85,17 +81,17 @@ export default async function DeckListPage({
                   <span>{deck.cards.length} cards</span>
                   <span>deck</span>
                 </div>
-                <h2 className="mt-3 text-lg font-semibold uppercase tracking-[0.08em]">
+                <h2 className="mt-3 text-lg font-semibold">
                   <Link className="hover:text-[var(--terminal-fg)]" href={`/decks/${deck.slug}`}>
                     {deck.name}
                   </Link>
                 </h2>
-                {deck.description && (
-                  <p className="mt-3 text-sm leading-6 text-[var(--terminal-muted)]">
-                    {deck.description}
-                  </p>
+                <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">
+                  {deck.shortPitch ?? deck.description}
+                </p>
+                {deck.description && deck.shortPitch && (
+                  <p className="mt-2 text-xs leading-6 text-[var(--terminal-muted)]">{deck.description}</p>
                 )}
-                <div className="mt-3 h-px bg-[var(--terminal-border)]" />
                 <div className="mt-4 flex flex-wrap gap-2">
                   {deck.tags.map((tag) => (
                     <span key={tag} className="terminal-chip">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,7 @@
   --terminal-accent: #39c5bb;
   --terminal-amber: #ffb86b;
   --terminal-muted: #4f7d86;
+  --terminal-soft: #a7d7d2;
   --terminal-error: #ff6b8f;
   --terminal-border: rgba(57, 197, 187, 0.38);
   --terminal-border-strong: rgba(126, 252, 242, 0.8);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { filterCards, listCards, listTags, searchCards } from "@/lib/cards";
+import { listDecks } from "@/lib/decks";
 
 type Props = {
   searchParams?: Promise<{ tag?: string; q?: string }>;
@@ -10,35 +11,41 @@ export default async function Home({ searchParams }: Props) {
   const tag = resolvedSearchParams.tag;
   const query = resolvedSearchParams.q ?? "";
   const allCards = await listCards();
+  const allDecks = await listDecks();
+  const searchedCards = searchCards(query, allCards);
   const cards = filterCards(tag, allCards).filter((card) =>
-    searchCards(query, allCards).some((matched) => matched.slug === card.slug)
+    searchedCards.some((matched) => matched.slug === card.slug)
   );
   const tags = listTags(allCards);
+  const featuredDecks = allDecks.filter((deck) => deck.featured).slice(0, 3);
+  const highlightedCards = allCards.slice(0, 4);
 
   return (
     <div className="min-h-screen text-white">
       <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-12">
         <header className="terminal-shell overflow-hidden">
           <div className="terminal-titlebar">
-            <span>voxie://miku-archive</span>
+            <span>voxie://archive</span>
             <span>status [live]</span>
           </div>
-          <div className="grid gap-8 px-5 py-6 sm:px-8 sm:py-8 md:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)] md:items-end">
+          <div className="grid gap-8 px-5 py-6 sm:px-8 sm:py-8 md:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)] md:items-start">
             <div>
               <p className="text-xs uppercase tracking-[0.3em] text-[var(--terminal-accent)]">
-                Hatsune Miku Console
+                vocaloid archive interface
               </p>
-              <h1 className="mt-3 text-4xl font-semibold uppercase tracking-[0.18em] sm:text-5xl">
-                Voxie
-                <span className="ml-2 cursor-blink text-[var(--terminal-accent)]">█</span>
+              <h1 className="mt-4 text-4xl font-semibold leading-tight sm:text-5xl">
+                보컬로이드 곡과 모먼트를 카드로 모으고, 덱으로 큐레이션하는 아카이브
               </h1>
-              <p className="mt-4 max-w-2xl text-sm leading-6 text-[var(--terminal-muted)] sm:text-base">
-                보컬로이드 순간을 카드로 모으는 커뮤니티 아카이브. 미쿠 블루그린
-                phosphor 톤으로 다시 튜닝한 터미널 UI예요.
+              <p className="mt-4 max-w-2xl text-sm leading-7 text-[var(--terminal-soft)] sm:text-base">
+                좋아하는 곡, 장면, 감정선, 해석을 카드로 남기고 테마별 덱으로 묶어보세요.
+                Voxie는 단순 목록이 아니라 왜 이 곡을 기억하는지까지 쌓아가는 커뮤니티형 컬렉션을 목표로 합니다.
               </p>
               <div className="mt-6 flex flex-wrap gap-3 text-sm">
-                <Link className="terminal-button" href="/decks">
-                  [ 덱 보기 ]
+                <Link className="terminal-button" href="#cards">
+                  [ 카드 둘러보기 ]
+                </Link>
+                <Link className="terminal-button" href="#featured-decks">
+                  [ 예시 덱 보기 ]
                 </Link>
                 <Link className="terminal-button" href="/cards/new">
                   [ 카드 작성 ]
@@ -46,30 +53,82 @@ export default async function Home({ searchParams }: Props) {
               </div>
             </div>
 
-            <div className="terminal-frame p-4 sm:p-5">
+            <aside className="terminal-frame p-4 sm:p-5">
               <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.18em] text-[var(--terminal-muted)]">
                 <span>signal</span>
-                <span>{cards.length.toString().padStart(2, "0")} cards</span>
+                <span>{cards.length.toString().padStart(2, "0")} visible</span>
               </div>
-              <div className="mt-4 space-y-3 text-sm">
-                <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
-                  <span className="text-[var(--terminal-muted)]">theme</span>
-                  <span className="text-[var(--terminal-fg)]">miku://39c5bb</span>
+              <div className="mt-4 grid gap-3 text-sm sm:grid-cols-3 md:grid-cols-1">
+                <div className="border border-[var(--terminal-border)] px-3 py-3">
+                  <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--terminal-muted)]">cards</p>
+                  <p className="mt-2 text-2xl font-semibold text-[var(--terminal-fg)]">{allCards.length}</p>
+                  <p className="mt-1 text-xs text-[var(--terminal-muted)]">곡/모먼트 기록</p>
                 </div>
-                <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
-                  <span className="text-[var(--terminal-muted)]">tags</span>
-                  <span className="text-[var(--terminal-fg)]">{tags.length}</span>
+                <div className="border border-[var(--terminal-border)] px-3 py-3">
+                  <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--terminal-muted)]">decks</p>
+                  <p className="mt-2 text-2xl font-semibold text-[var(--terminal-fg)]">{allDecks.length}</p>
+                  <p className="mt-1 text-xs text-[var(--terminal-muted)]">큐레이션 묶음</p>
                 </div>
-                <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
-                  <span className="text-[var(--terminal-muted)]">query</span>
-                  <span className="truncate pl-4 text-right text-[var(--terminal-fg)]">
-                    {query || "--all"}
-                  </span>
+                <div className="border border-[var(--terminal-border)] px-3 py-3">
+                  <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--terminal-muted)]">tags</p>
+                  <p className="mt-2 text-2xl font-semibold text-[var(--terminal-fg)]">{tags.length}</p>
+                  <p className="mt-1 text-xs text-[var(--terminal-muted)]">탐색 포인트</p>
                 </div>
               </div>
-            </div>
+            </aside>
           </div>
         </header>
+
+        <section className="mt-8 grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+          <article className="terminal-frame p-5 sm:p-6">
+            <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">cards → decks → archive</p>
+            <div className="mt-4 grid gap-4 sm:grid-cols-3">
+              <div>
+                <p className="font-semibold text-[var(--terminal-fg)]">1. 카드</p>
+                <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">
+                  곡, 장면, 감정 포인트를 하나의 기록 단위로 남깁니다.
+                </p>
+              </div>
+              <div>
+                <p className="font-semibold text-[var(--terminal-fg)]">2. 덱</p>
+                <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">
+                  같은 시대, 프로듀서, 분위기의 카드를 맥락으로 묶습니다.
+                </p>
+              </div>
+              <div>
+                <p className="font-semibold text-[var(--terminal-fg)]">3. 아카이브</p>
+                <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">
+                  단순 DB가 아니라 왜 기억되는지까지 읽히는 컬렉션을 만듭니다.
+                </p>
+              </div>
+            </div>
+          </article>
+
+          <article id="featured-decks" className="terminal-frame p-5 sm:p-6">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">featured decks</p>
+                <h2 className="mt-2 text-xl font-semibold">덱이 왜 필요한지 먼저 보여주기</h2>
+              </div>
+              <Link className="text-sm text-[var(--terminal-fg)]" href="/decks">
+                전체 덱 보기 →
+              </Link>
+            </div>
+            <div className="mt-4 space-y-3">
+              {featuredDecks.map((deck) => (
+                <Link key={deck.slug} href={`/decks/${deck.slug}`} className="block border border-[var(--terminal-border)] px-4 py-4">
+                  <div className="flex items-center justify-between gap-4 text-xs uppercase tracking-[0.14em] text-[var(--terminal-muted)]">
+                    <span>{deck.name}</span>
+                    <span>{deck.cards.length} cards</span>
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">
+                    {deck.shortPitch ?? deck.description}
+                  </p>
+                </Link>
+              ))}
+            </div>
+          </article>
+        </section>
 
         <section className="mt-8 terminal-shell overflow-hidden">
           <div className="terminal-titlebar">
@@ -82,7 +141,7 @@ export default async function Home({ searchParams }: Props) {
                 type="text"
                 name="q"
                 defaultValue={query}
-                placeholder="search --cards"
+                placeholder="곡, 캐릭터, 프로듀서 검색"
                 className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
               />
               <button type="submit" className="terminal-button sm:min-w-36">
@@ -114,15 +173,13 @@ export default async function Home({ searchParams }: Props) {
           </div>
         </section>
 
-        <section className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <section id="cards" className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {cards.length === 0 ? (
             <article className="terminal-shell px-6 py-10 md:col-span-2 xl:col-span-3">
               <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">
                 no results detected
               </p>
-              <h2 className="mt-3 text-2xl font-semibold uppercase tracking-[0.12em]">
-                검색 결과가 없어요
-              </h2>
+              <h2 className="mt-3 text-2xl font-semibold">검색 결과가 없어요</h2>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--terminal-muted)]">
                 다른 태그를 선택하거나 검색어를 줄여보세요. 필요하면 새 카드를 바로 추가해서
                 아카이브를 채울 수도 있어요.
@@ -140,12 +197,18 @@ export default async function Home({ searchParams }: Props) {
                   <span>{card.character}</span>
                   <span>{card.type}</span>
                 </div>
-                <h2 className="mt-3 text-lg font-semibold uppercase tracking-[0.08em]">
+                <h2 className="mt-3 text-lg font-semibold">
                   <Link className="hover:text-[var(--terminal-fg)]" href={`/cards/${card.slug}`}>
                     {card.title}
                   </Link>
                 </h2>
-                <div className="mt-2 h-px bg-[var(--terminal-border)]" />
+                {card.summary && (
+                  <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">{card.summary}</p>
+                )}
+                <div className="mt-3 flex flex-wrap gap-2 text-xs text-[var(--terminal-muted)]">
+                  {card.producer && <span>Producer: {card.producer}</span>}
+                  {card.year && <span>Year: {card.year}</span>}
+                </div>
                 <div className="mt-4 flex flex-wrap gap-2">
                   {card.tags.map((item) => (
                     <span key={item} className="terminal-chip">
@@ -153,19 +216,29 @@ export default async function Home({ searchParams }: Props) {
                     </span>
                   ))}
                 </div>
-                {card.source_url && (
-                  <a
-                    href={card.source_url}
-                    className="mt-4 inline-flex text-xs uppercase tracking-[0.12em] text-[var(--terminal-fg)]"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    source --open
-                  </a>
-                )}
               </article>
             ))
           )}
+        </section>
+
+        <section className="mt-8">
+          <div className="mb-4 flex items-center justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">highlight cards</p>
+              <h2 className="mt-2 text-xl font-semibold">대표 카드만 봐도 서비스 목적이 보이도록</h2>
+            </div>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {highlightedCards.map((card) => (
+              <Link key={card.slug} href={`/cards/${card.slug}`} className="terminal-frame block p-4">
+                <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-soft)]">
+                  {card.year ?? "archive"}
+                </p>
+                <p className="mt-8 text-lg font-semibold">{card.title}</p>
+                <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">{card.summary}</p>
+              </Link>
+            ))}
+          </div>
         </section>
       </main>
     </div>

--- a/src/data/card-details.ts
+++ b/src/data/card-details.ts
@@ -1,0 +1,72 @@
+export type CardDetailSeed = {
+  summary: string;
+  description: string[];
+  producer?: string;
+  year?: number;
+  era?: string;
+  mood?: string[];
+  whyItMatters?: string;
+};
+
+export const cardDetails: Record<string, CardDetailSeed> = {
+  melt: {
+    summary: "초기 미쿠 붐을 대표하는 러브송 클래식.",
+    description: [
+      "Melt는 보컬로이드가 단순 실험작이 아니라 대중적으로 사랑받는 팝송이 될 수 있다는 걸 보여준 상징적인 곡이에요.",
+      "직설적인 감정 표현과 밝은 멜로디 덕분에 입문자에게도 설명하기 쉬운 카드이고, 초기 니코동 시대의 열기를 떠올리게 하는 기준점 역할도 해요.",
+    ],
+    producer: "ryo (supercell)",
+    year: 2007,
+    era: "NicoNico golden age",
+    mood: ["bright", "romance", "classic"],
+    whyItMatters: "Voxie에서 카드로 남길 가치가 분명한 '시대의 기준점' 같은 곡이에요.",
+  },
+  "world-is-mine": {
+    summary: "미쿠 캐릭터성을 대중적으로 각인시킨 아이코닉 트랙.",
+    description: [
+      "World is Mine은 '공주님 같은 미쿠'라는 팬덤 이미지를 폭발적으로 확산시킨 대표곡이에요.",
+      "곡 자체의 인지도도 높지만, 공연 연출과 팬덤 밈까지 포함해 다양한 모먼트를 덱으로 연결하기 좋은 카드예요.",
+    ],
+    producer: "ryo (supercell)",
+    year: 2008,
+    era: "Character-defining classics",
+    mood: ["playful", "iconic", "performance"],
+    whyItMatters: "단일 곡을 넘어 캐릭터 해석과 무대 연출의 출발점이 되는 카드예요.",
+  },
+  "rolling-girl": {
+    summary: "강한 질주감과 불안한 감정선이 겹치는 wowaka 대표곡.",
+    description: [
+      "Rolling Girl은 속도감 있는 록 사운드와 반복되는 정서가 겹치면서, 듣는 순간 강한 감정 잔상을 남기는 곡이에요.",
+      "Voxie에서는 단순 곡 정보보다도 '왜 사람들이 이 곡을 계속 기억하는지'를 기록하기 좋은 카드로 기능할 수 있어요.",
+    ],
+    producer: "wowaka",
+    year: 2010,
+    era: "Band sound / emotional classics",
+    mood: ["restless", "cathartic", "rock"],
+    whyItMatters: "개별 카드만으로도 설명과 감상을 읽을 이유가 생기는 대표 사례예요.",
+  },
+  "ievan-polkka": {
+    summary: "밈과 퍼포먼스로 폭발적으로 확산된 초기 바이럴 미쿠 카드.",
+    description: [
+      "Ievan Polkka는 곡 자체보다도 '파 돌리기' 같은 문화적 밈과 함께 회자되는, 인터넷적 확산력을 상징하는 카드예요.",
+      "덕분에 카드 아카이브 안에서도 음악·밈·캐릭터 이미지가 어떻게 합쳐졌는지 보여주는 좋은 연결점이 됩니다.",
+    ],
+    producer: "Otomania arrangement / cover culture",
+    year: 2007,
+    era: "Viral internet moments",
+    mood: ["meme", "playful", "folk"],
+    whyItMatters: "곡 그 자체뿐 아니라 팬덤 문화의 전파 경로까지 묶어 보여주기 좋아요.",
+  },
+  "reverse-rainbow": {
+    summary: "무드와 하모니를 중심으로 기억되는 감성 듀엣 카드.",
+    description: [
+      "Reverse Rainbow는 폭발적인 대표곡 계열과는 조금 다르게, 감성적인 톤과 조합의 매력으로 기억되는 카드예요.",
+      "이런 카드가 있어야 Voxie가 '유명곡 목록'을 넘어 개인적 취향과 분위기 큐레이션이 가능한 아카이브로 보이게 됩니다.",
+    ],
+    producer: "Treow (electrosphere)",
+    year: 2009,
+    era: "Atmospheric duet picks",
+    mood: ["dreamy", "duet", "late-night"],
+    whyItMatters: "덱 기능이 단순 분류가 아니라 분위기 큐레이션이라는 걸 보여주는 카드예요.",
+  },
+};

--- a/src/data/deck-details.ts
+++ b/src/data/deck-details.ts
@@ -1,0 +1,20 @@
+export type DeckDetailSeed = {
+  shortPitch?: string;
+  curatorNote?: string;
+  featured?: boolean;
+};
+
+export const deckDetails: Record<string, DeckDetailSeed> = {
+  "classic-miku": {
+    shortPitch: "처음 Voxie에 들어온 사람이 서비스 가치를 바로 이해하게 해주는 입문용 덱.",
+    curatorNote:
+      "초기 미쿠 대표곡을 한 번에 묶어 '카드를 왜 덱으로 엮는가'를 가장 직관적으로 보여주는 큐레이션이에요.",
+    featured: true,
+  },
+  "stage-hits": {
+    shortPitch: "라이브와 퍼포먼스 맥락으로 다시 보는 카드 묶음.",
+    curatorNote:
+      "같은 곡도 공연과 밈의 기억으로 다시 읽히기 때문에, 덱은 단순 목록이 아니라 맥락을 담는 단위가 됩니다.",
+    featured: true,
+  },
+};

--- a/src/lib/cards.ts
+++ b/src/lib/cards.ts
@@ -1,4 +1,5 @@
 import seed from "@/data/seed.json";
+import { cardDetails } from "@/data/card-details";
 import { isSupabaseConfigured, supabase } from "@/lib/supabase/client";
 import { isMockWriteModeEnabled, listMockCards } from "@/lib/mock-db";
 
@@ -9,9 +10,33 @@ export type Card = {
   character: string;
   tags: string[];
   source_url?: string;
+  summary?: string;
+  description?: string[];
+  producer?: string;
+  year?: number;
+  era?: string;
+  mood?: string[];
+  whyItMatters?: string;
 };
 
-export const cards = seed as Card[];
+export const cards = (seed as Array<Omit<Card, "summary" | "description" | "producer" | "year" | "era" | "mood" | "whyItMatters">>).map(
+  (card) => ({
+    ...card,
+    ...cardDetails[card.slug],
+  })
+);
+
+const enrichCard = (card: {
+  slug: string;
+  title: string;
+  type: string;
+  character: string;
+  tags: string[];
+  source_url?: string;
+}): Card => ({
+  ...card,
+  ...cardDetails[card.slug],
+});
 
 const normalizeCard = (card: {
   slug: string;
@@ -20,14 +45,15 @@ const normalizeCard = (card: {
   character: string;
   tags: string[] | null;
   source_url: string | null;
-}): Card => ({
-  slug: card.slug,
-  title: card.title,
-  type: card.type,
-  character: card.character,
-  tags: card.tags ?? [],
-  source_url: card.source_url ?? undefined,
-});
+}): Card =>
+  enrichCard({
+    slug: card.slug,
+    title: card.title,
+    type: card.type,
+    character: card.character,
+    tags: card.tags ?? [],
+    source_url: card.source_url ?? undefined,
+  });
 
 export const listTags = (items: Card[] = cards) => {
   const set = new Set<string>();
@@ -51,13 +77,14 @@ export const searchCards = (query: string, items: Card[] = cards) => {
     return (
       card.title.toLowerCase().includes(normalized) ||
       card.character.toLowerCase().includes(normalized) ||
+      (card.producer?.toLowerCase().includes(normalized) ?? false) ||
       card.tags.some((tag) => tag.toLowerCase().includes(normalized))
     );
   });
 };
 
 export const listCards = async (): Promise<Card[]> => {
-  if (isMockWriteModeEnabled()) return listMockCards();
+  if (isMockWriteModeEnabled()) return listMockCards().map(enrichCard);
   if (!isSupabaseConfigured() || !supabase) return cards;
 
   const { data, error } = await supabase
@@ -74,7 +101,10 @@ export const listCards = async (): Promise<Card[]> => {
 };
 
 export const getCardBySlugAsync = async (slug: string): Promise<Card | undefined> => {
-  if (isMockWriteModeEnabled()) return getCardBySlug(slug, listMockCards());
+  if (isMockWriteModeEnabled()) {
+    const card = getCardBySlug(slug, listMockCards());
+    return card ? enrichCard(card) : undefined;
+  }
   if (!isSupabaseConfigured() || !supabase) return getCardBySlug(slug);
 
   const { data, error } = await supabase
@@ -89,4 +119,14 @@ export const getCardBySlugAsync = async (slug: string): Promise<Card | undefined
   }
 
   return normalizeCard(data);
+};
+
+export const getCardExternalLinks = (card: Card) => {
+  const query = encodeURIComponent(`${card.title} ${card.character}`);
+
+  return {
+    source: card.source_url,
+    youtubeSearch: `https://www.youtube.com/results?search_query=${query}`,
+    niconicoSearch: `https://www.nicovideo.jp/search/${query}`,
+  };
 };

--- a/src/lib/decks.ts
+++ b/src/lib/decks.ts
@@ -1,4 +1,5 @@
 import decksSeed from "@/data/decks.json";
+import { deckDetails } from "@/data/deck-details";
 import { isSupabaseConfigured, supabase } from "@/lib/supabase/client";
 import { isMockWriteModeEnabled, listMockDecks } from "@/lib/mock-db";
 
@@ -8,9 +9,17 @@ export type Deck = {
   description?: string;
   tags: string[];
   cards: string[];
+  shortPitch?: string;
+  curatorNote?: string;
+  featured?: boolean;
 };
 
-export const decks = decksSeed as Deck[];
+export const decks = (decksSeed as Array<Omit<Deck, "shortPitch" | "curatorNote" | "featured">>).map(
+  (deck) => ({
+    ...deck,
+    ...deckDetails[deck.slug],
+  })
+);
 
 type SupabaseDeckRow = {
   slug: string;
@@ -23,16 +32,28 @@ type SupabaseDeckRow = {
   }> | null;
 };
 
-const normalizeDeck = (deck: SupabaseDeckRow): Deck => ({
-  slug: deck.slug,
-  name: deck.name,
-  description: deck.description ?? undefined,
-  tags: deck.tags ?? [],
-  cards: (deck.deck_cards ?? [])
-    .sort((a, b) => a.position - b.position)
-    .map((item) => item.cards?.slug)
-    .filter((slug): slug is string => Boolean(slug)),
+const enrichDeck = (deck: {
+  slug: string;
+  name: string;
+  description?: string;
+  tags: string[];
+  cards: string[];
+}): Deck => ({
+  ...deck,
+  ...deckDetails[deck.slug],
 });
+
+const normalizeDeck = (deck: SupabaseDeckRow): Deck =>
+  enrichDeck({
+    slug: deck.slug,
+    name: deck.name,
+    description: deck.description ?? undefined,
+    tags: deck.tags ?? [],
+    cards: (deck.deck_cards ?? [])
+      .sort((a, b) => a.position - b.position)
+      .map((item) => item.cards?.slug)
+      .filter((slug): slug is string => Boolean(slug)),
+  });
 
 export const getDeckBySlug = (slug: string, items: Deck[] = decks) =>
   items.find((deck) => deck.slug === slug);
@@ -45,13 +66,14 @@ export const searchDecks = (query: string, items: Deck[] = decks) => {
     return (
       deck.name.toLowerCase().includes(normalized) ||
       (deck.description?.toLowerCase().includes(normalized) ?? false) ||
+      (deck.shortPitch?.toLowerCase().includes(normalized) ?? false) ||
       deck.tags.some((tag) => tag.toLowerCase().includes(normalized))
     );
   });
 };
 
 export const listDecks = async (): Promise<Deck[]> => {
-  if (isMockWriteModeEnabled()) return listMockDecks();
+  if (isMockWriteModeEnabled()) return listMockDecks().map(enrichDeck);
   if (!isSupabaseConfigured() || !supabase) return decks;
 
   const { data, error } = await supabase
@@ -70,7 +92,7 @@ export const listDecks = async (): Promise<Deck[]> => {
 };
 
 export const getDeckBySlugAsync = async (slug: string): Promise<Deck | undefined> => {
-  if (isMockWriteModeEnabled()) return getDeckBySlug(slug, listMockDecks());
+  if (isMockWriteModeEnabled()) return getDeckBySlug(slug, listMockDecks().map(enrichDeck));
   if (!isSupabaseConfigured() || !supabase) return getDeckBySlug(slug);
 
   const { data, error } = await supabase


### PR DESCRIPTION
## 🎵 변경 사항
- 홈페이지 헤드라인, UI 텍스트 및 레이아웃을 '아카이브'라는 목적에 맞게 전면 개선했습니다.
- 테마별 덱(덱 생성 시 설명, 소개 등)을 통해 컬렉션으로서의 정체성을 강화했습니다.
- 곡/모먼트에 대해 메타데이터(요약, 에라, 설명, 발매일, 외부 링크 등)를 채울 수 있도록 정적 시드(, )를 분리하고 렌더링 로직을 반영했습니다.
- Next.js UI(Tailwind 4)에서 `terminal-shell` 및 `terminal-frame` 클래스 위주로 전반적인 스타일 리팩터링을 진행했습니다.
- 불필요한 Git rebase 충돌을 해결하고 병합을 완료했습니다.

## 🎤 동기 / 맥락
- 초기 MVP 런칭 당시 '카드 상세가 비어있다', '비주얼 장식에 비해 첫인상 메시지가 불명확하다'는 피드백이 있어 이를 개선하기 위함입니다.
- 관련 지침: '비주얼 컨셉은 유지하되, 제품 의미를 더 선명하게 만들기'

## 🎹 테스트
- [x] 유닛 테스트 전체 통과 확인 완료
- [x] 타입 체크 통과 확인 완료
- [x] 로컬 환경 UI 충돌 없음 확인 완료