### PR TITLE
fix(ui): make Voxie feel like a service, not a landing page

### DIFF
--- a/src/app/cards/[slug]/page.tsx
+++ b/src/app/cards/[slug]/page.tsx
@@ -17,7 +17,7 @@ export default async function CardDetail({ params }: Props) {
           <div className="terminal-shell px-6 py-10">
             <p className="text-sm text-[var(--terminal-muted)]">카드를 찾을 수 없어요.</p>
             <Link className="mt-6 inline-flex terminal-button" href="/">
-              [ 목록으로 ]
+              목록으로
             </Link>
           </div>
         </main>
@@ -31,23 +31,16 @@ export default async function CardDetail({ params }: Props) {
 
   return (
     <div className="min-h-screen text-white">
-      <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 sm:py-12">
-        <header className="terminal-shell overflow-hidden">
-          <div className="terminal-titlebar">
-            <span>card://{card.slug}</span>
-            <span>{card.type.toUpperCase()}</span>
-          </div>
-          <div className="grid gap-6 px-5 py-6 sm:px-8 sm:py-8 md:grid-cols-[minmax(0,1fr)_280px]">
+      <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 sm:py-10">
+        <header className="terminal-shell p-5 sm:p-6">
+          <Link className="text-sm text-[var(--terminal-muted)]" href="/">
+            ← 카드 목록
+          </Link>
+          <div className="mt-4 grid gap-6 md:grid-cols-[minmax(0,1fr)_280px]">
             <div>
-              <Link
-                className="text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)] hover:text-[var(--terminal-fg)]"
-                href="/"
-              >
-                ← return --cards
-              </Link>
-              <h1 className="mt-4 text-3xl font-semibold sm:text-4xl">{card.title}</h1>
+              <h1 className="text-3xl font-semibold sm:text-4xl">{card.title}</h1>
               {card.summary && (
-                <p className="mt-4 max-w-2xl text-sm leading-7 text-[var(--terminal-soft)] sm:text-base">
+                <p className="mt-3 max-w-2xl text-sm leading-7 text-[var(--terminal-soft)] sm:text-base">
                   {card.summary}
                 </p>
               )}
@@ -63,24 +56,24 @@ export default async function CardDetail({ params }: Props) {
             <aside className="terminal-frame p-4">
               <div className="space-y-3 text-sm">
                 <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
-                  <span className="text-[var(--terminal-muted)]">character</span>
+                  <span className="text-[var(--terminal-muted)]">캐릭터</span>
                   <span>{card.character}</span>
                 </div>
                 {card.producer && (
                   <div className="flex items-center justify-between gap-4 border border-[var(--terminal-border)] px-3 py-2">
-                    <span className="text-[var(--terminal-muted)]">producer</span>
+                    <span className="text-[var(--terminal-muted)]">프로듀서</span>
                     <span className="text-right">{card.producer}</span>
                   </div>
                 )}
                 {card.year && (
                   <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
-                    <span className="text-[var(--terminal-muted)]">year</span>
+                    <span className="text-[var(--terminal-muted)]">연도</span>
                     <span>{card.year}</span>
                   </div>
                 )}
                 {card.era && (
                   <div className="flex items-center justify-between gap-4 border border-[var(--terminal-border)] px-3 py-2">
-                    <span className="text-[var(--terminal-muted)]">era</span>
+                    <span className="text-[var(--terminal-muted)]">시기</span>
                     <span className="text-right">{card.era}</span>
                   </div>
                 )}
@@ -91,7 +84,7 @@ export default async function CardDetail({ params }: Props) {
 
         <section className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
           <article className="terminal-frame p-5 sm:p-6">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">archive note</p>
+            <h2 className="text-lg font-semibold">설명</h2>
             {card.description ? (
               <div className="mt-4 space-y-4 text-sm leading-7 text-[var(--terminal-soft)]">
                 {card.description.map((paragraph) => (
@@ -104,13 +97,13 @@ export default async function CardDetail({ params }: Props) {
 
             {card.whyItMatters && (
               <div className="mt-6 border border-[var(--terminal-border)] px-4 py-4">
-                <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">why this card matters</p>
-                <p className="mt-3 text-sm leading-7 text-[var(--terminal-fg)]">{card.whyItMatters}</p>
+                <p className="text-sm font-semibold text-[var(--terminal-fg)]">왜 이 카드가 중요한가</p>
+                <p className="mt-3 text-sm leading-7 text-[var(--terminal-soft)]">{card.whyItMatters}</p>
               </div>
             )}
 
             <div className="mt-6">
-              <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">mood / usage</p>
+              <p className="text-sm font-semibold text-[var(--terminal-fg)]">무드</p>
               <div className="mt-3 flex flex-wrap gap-2">
                 {(card.mood ?? card.tags).map((item) => (
                   <span key={item} className="terminal-chip" data-active="true">
@@ -123,38 +116,27 @@ export default async function CardDetail({ params }: Props) {
 
           <aside className="space-y-6">
             <section className="terminal-frame p-5">
-              <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">signal preview</p>
-              <div className="mt-4 flex aspect-[4/3] items-end border border-[var(--terminal-border)] bg-[radial-gradient(circle_at_top,rgba(57,197,187,0.28)_0%,rgba(8,17,29,0.95)_55%,rgba(3,5,13,1)_100%)] p-5">
-                <div>
-                  <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-soft)]">{card.character}</p>
-                  <p className="mt-2 text-2xl font-semibold text-[var(--terminal-fg)]">{card.title}</p>
-                  <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">{card.summary}</p>
-                </div>
-              </div>
-            </section>
-
-            <section className="terminal-frame p-5">
-              <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">listen / reference</p>
+              <h2 className="text-lg font-semibold">바로 가기</h2>
               <div className="mt-4 flex flex-col gap-3 text-sm">
                 {links.source && (
                   <a href={links.source} target="_blank" rel="noreferrer" className="terminal-button text-center">
-                    [ reference source ]
+                    원문 보기
                   </a>
                 )}
                 <a href={links.youtubeSearch} target="_blank" rel="noreferrer" className="terminal-button text-center">
-                  [ search on youtube ]
+                  YouTube 검색
                 </a>
                 <a href={links.niconicoSearch} target="_blank" rel="noreferrer" className="terminal-button text-center">
-                  [ search on niconico ]
+                  니코동 검색
                 </a>
               </div>
             </section>
 
             <section className="terminal-frame p-5">
               <div className="flex items-center justify-between gap-4">
-                <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">included in decks</p>
-                <Link href="/decks" className="text-xs text-[var(--terminal-fg)]">
-                  모든 덱 보기 →
+                <h2 className="text-lg font-semibold">포함된 덱</h2>
+                <Link href="/decks" className="text-sm text-[var(--terminal-soft)]">
+                  전체 보기 →
                 </Link>
               </div>
               <div className="mt-4 space-y-3">
@@ -162,7 +144,7 @@ export default async function CardDetail({ params }: Props) {
                   relatedDecks.map((deck) => (
                     <Link key={deck.slug} href={`/decks/${deck.slug}`} className="block border border-[var(--terminal-border)] px-4 py-4">
                       <p className="text-sm font-semibold">{deck.name}</p>
-                      <p className="mt-1 text-xs leading-6 text-[var(--terminal-muted)]">
+                      <p className="mt-1 text-sm leading-6 text-[var(--terminal-muted)]">
                         {deck.shortPitch ?? deck.description}
                       </p>
                     </Link>

--- a/src/app/decks/[slug]/page.tsx
+++ b/src/app/decks/[slug]/page.tsx
@@ -17,7 +17,7 @@ export default async function DeckDetailPage({ params }: Props) {
           <div className="terminal-shell px-6 py-10">
             <p className="text-sm text-[var(--terminal-muted)]">덱을 찾을 수 없어요.</p>
             <Link className="mt-6 inline-flex terminal-button" href="/decks">
-              [ 덱 목록으로 ]
+              덱 목록으로
             </Link>
           </div>
         </main>
@@ -29,26 +29,20 @@ export default async function DeckDetailPage({ params }: Props) {
 
   return (
     <div className="min-h-screen text-white">
-      <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 sm:py-12">
-        <header className="terminal-shell overflow-hidden">
-          <div className="terminal-titlebar">
-            <span>deck://{deck.slug}</span>
-            <span>{cards.length.toString().padStart(2, "0")} cards</span>
+      <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 sm:py-10">
+        <header className="terminal-shell p-5 sm:p-6">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <Link className="text-sm text-[var(--terminal-muted)]" href="/decks">
+              ← 덱 목록
+            </Link>
+            <Link className="terminal-button" href={`/decks/${deck.slug}/edit`}>
+              덱 수정
+            </Link>
           </div>
-          <div className="grid gap-6 px-5 py-6 sm:px-8 sm:py-8 md:grid-cols-[minmax(0,1fr)_260px]">
+
+          <div className="mt-4 grid gap-6 md:grid-cols-[minmax(0,1fr)_260px]">
             <div>
-              <div className="flex flex-wrap items-center gap-3">
-                <Link
-                  className="text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)] hover:text-[var(--terminal-fg)]"
-                  href="/decks"
-                >
-                  ← return --decks
-                </Link>
-                <Link className="terminal-button text-xs" href={`/decks/${deck.slug}/edit`}>
-                  [ edit deck ]
-                </Link>
-              </div>
-              <h1 className="mt-4 text-3xl font-semibold sm:text-4xl">{deck.name}</h1>
+              <h1 className="text-3xl font-semibold sm:text-4xl">{deck.name}</h1>
               {deck.description && (
                 <p className="mt-3 max-w-2xl text-sm leading-7 text-[var(--terminal-soft)]">
                   {deck.description}
@@ -66,17 +60,17 @@ export default async function DeckDetailPage({ params }: Props) {
             <aside className="terminal-frame p-4">
               <div className="space-y-3 text-sm">
                 <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
-                  <span className="text-[var(--terminal-muted)]">cards</span>
+                  <span className="text-[var(--terminal-muted)]">카드 수</span>
                   <span>{cards.length}</span>
                 </div>
                 <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
-                  <span className="text-[var(--terminal-muted)]">tags</span>
+                  <span className="text-[var(--terminal-muted)]">태그 수</span>
                   <span>{deck.tags.length}</span>
                 </div>
                 {deck.featured && (
                   <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
-                    <span className="text-[var(--terminal-muted)]">featured</span>
-                    <span>yes</span>
+                    <span className="text-[var(--terminal-muted)]">추천 덱</span>
+                    <span>예</span>
                   </div>
                 )}
               </div>
@@ -86,43 +80,45 @@ export default async function DeckDetailPage({ params }: Props) {
 
         <section className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
           <article className="terminal-frame p-5 sm:p-6">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">why this deck exists</p>
-            <p className="mt-4 text-sm leading-7 text-[var(--terminal-fg)]">
+            <h2 className="text-lg font-semibold">요약</h2>
+            <p className="mt-4 text-sm leading-7 text-[var(--terminal-soft)]">
               {deck.shortPitch ?? "이 덱은 관련 카드들을 하나의 맥락으로 묶기 위한 큐레이션 단위예요."}
             </p>
 
             {deck.curatorNote && (
               <div className="mt-6 border border-[var(--terminal-border)] px-4 py-4">
-                <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">curator note</p>
+                <p className="text-sm font-semibold text-[var(--terminal-fg)]">큐레이터 메모</p>
                 <p className="mt-3 text-sm leading-7 text-[var(--terminal-soft)]">{deck.curatorNote}</p>
               </div>
             )}
           </article>
 
           <aside className="terminal-frame p-5">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">deck preview</p>
+            <h2 className="text-lg font-semibold">미리 보기</h2>
             <div className="mt-4 space-y-3">
               {cards.slice(0, 3).map((card) => (
                 <div key={card?.slug} className="border border-[var(--terminal-border)] px-4 py-4">
                   <p className="text-sm font-semibold text-[var(--terminal-fg)]">{card?.title}</p>
-                  <p className="mt-1 text-xs leading-6 text-[var(--terminal-muted)]">{card?.summary}</p>
+                  <p className="mt-1 text-sm leading-6 text-[var(--terminal-muted)]">{card?.summary}</p>
                 </div>
               ))}
             </div>
-            <p className="mt-4 text-sm leading-7 text-[var(--terminal-muted)]">
-              덱은 단순히 카드를 모아두는 박스가 아니라, 시대·감정·프로듀서·무대 맥락을 함께 읽게 해주는 큐레이션 단위예요.
-            </p>
           </aside>
         </section>
 
         <section className="mt-8 grid gap-4">
+          <div>
+            <h2 className="text-lg font-semibold">포함된 카드</h2>
+            <p className="mt-1 text-sm text-[var(--terminal-muted)]">이 덱에 묶인 카드 목록입니다.</p>
+          </div>
+
           {cards.map((card) => (
             <div key={card?.slug} className="terminal-frame p-5">
-              <div className="flex items-center justify-between text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)]">
+              <div className="flex items-center justify-between text-xs text-[var(--terminal-muted)]">
                 <span>{card?.character}</span>
                 <span>{card?.type}</span>
               </div>
-              <Link className="mt-3 inline-flex text-lg font-semibold hover:text-[var(--terminal-fg)]" href={`/cards/${card?.slug}`}>
+              <Link className="mt-3 inline-flex text-lg font-semibold" href={`/cards/${card?.slug}`}>
                 {card?.title}
               </Link>
               {card?.summary && <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">{card.summary}</p>}

--- a/src/app/decks/page.tsx
+++ b/src/app/decks/page.tsx
@@ -13,84 +13,67 @@ export default async function DeckListPage({
 
   return (
     <div className="min-h-screen text-white">
-      <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-12">
-        <header className="terminal-shell overflow-hidden">
-          <div className="terminal-titlebar">
-            <span>playlist://decks</span>
-            <span>{decks.length.toString().padStart(2, "0")} results</span>
-          </div>
-          <div className="px-5 py-6 sm:px-8 sm:py-8">
-            <h1 className="text-3xl font-semibold sm:text-4xl">Decks</h1>
-            <p className="mt-3 max-w-2xl text-sm leading-7 text-[var(--terminal-soft)]">
-              카드들을 시대, 감정, 퍼포먼스 맥락으로 엮는 큐레이션 묶음이에요. 덱이 왜 존재하는지
-              바로 보이도록 설명과 예시를 함께 노출합니다.
-            </p>
-            <div className="mt-6 flex flex-wrap gap-3">
+      <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
+        <header className="terminal-shell p-5 sm:p-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <h1 className="text-2xl font-semibold sm:text-3xl">덱</h1>
+              <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">
+                카드들을 테마와 맥락으로 묶은 컬렉션 목록입니다.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
               <Link className="terminal-button" href="/decks/new">
-                [ 덱 생성 ]
+                덱 추가
               </Link>
               <Link className="terminal-button" href="/">
-                [ 카드 보기 ]
+                카드 보기
               </Link>
             </div>
           </div>
-        </header>
 
-        <section className="mt-8 terminal-shell overflow-hidden">
-          <div className="terminal-titlebar">
-            <span>search --decks</span>
-            <span>{query || "--all"}</span>
-          </div>
-          <div className="px-5 py-5 sm:px-6">
-            <form action="/decks" className="flex flex-col gap-3 sm:flex-row">
-              <input
-                type="text"
-                name="q"
-                defaultValue={query}
-                placeholder="덱 이름, 설명, 태그 검색"
-                className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
-              />
-              <button type="submit" className="terminal-button sm:min-w-36">
-                [ 검색 ]
-              </button>
-            </form>
-          </div>
-        </section>
+          <form action="/decks" className="mt-6 flex flex-col gap-3 sm:flex-row">
+            <input
+              type="text"
+              name="q"
+              defaultValue={query}
+              placeholder="덱 이름, 설명, 태그 검색"
+              className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
+            />
+            <button type="submit" className="terminal-button sm:min-w-32">
+              검색
+            </button>
+          </form>
+        </header>
 
         <section className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {decks.length === 0 ? (
             <article className="terminal-shell px-6 py-10 md:col-span-2 xl:col-span-3">
-              <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">
-                no decks loaded
-              </p>
-              <h2 className="mt-3 text-2xl font-semibold">아직 덱이 없어요</h2>
+              <h2 className="text-xl font-semibold">아직 덱이 없어요</h2>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--terminal-muted)]">
-                첫 플레이리스트를 만들면 카드들을 테마별로 묶어 볼 수 있어요. 미쿠 콘솔의 다음 패널은
-                덱 생성 화면이에요.
+                첫 덱을 만들면 카드들을 테마별로 정리해서 볼 수 있어요.
               </p>
               <div className="mt-6">
                 <Link className="terminal-button" href="/decks/new">
-                  [ 덱 생성 ]
+                  덱 추가
                 </Link>
               </div>
             </article>
           ) : (
             decks.map((deck) => (
               <article key={deck.slug} className="terminal-frame p-5">
-                <div className="flex items-center justify-between text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)]">
+                <div className="flex items-center justify-between text-xs text-[var(--terminal-muted)]">
                   <span>{deck.cards.length} cards</span>
-                  <span>deck</span>
+                  <span>{deck.featured ? "featured" : "deck"}</span>
                 </div>
                 <h2 className="mt-3 text-lg font-semibold">
-                  <Link className="hover:text-[var(--terminal-fg)]" href={`/decks/${deck.slug}`}>
-                    {deck.name}
-                  </Link>
+                  <Link href={`/decks/${deck.slug}`}>{deck.name}</Link>
                 </h2>
                 <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">
                   {deck.shortPitch ?? deck.description}
                 </p>
                 {deck.description && deck.shortPitch && (
-                  <p className="mt-2 text-xs leading-6 text-[var(--terminal-muted)]">{deck.description}</p>
+                  <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">{deck.description}</p>
                 )}
                 <div className="mt-4 flex flex-wrap gap-2">
                   {deck.tags.map((tag) => (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,16 +4,16 @@
   --terminal-bg: #050816;
   --terminal-bg-elevated: #0a1020;
   --terminal-panel: rgba(8, 14, 31, 0.92);
-  --terminal-fg: #7efcf2;
+  --terminal-fg: #d8fff9;
   --terminal-accent: #39c5bb;
   --terminal-amber: #ffb86b;
-  --terminal-muted: #4f7d86;
-  --terminal-soft: #a7d7d2;
+  --terminal-muted: #88aeb0;
+  --terminal-soft: #c0ece7;
   --terminal-error: #ff6b8f;
-  --terminal-border: rgba(57, 197, 187, 0.38);
-  --terminal-border-strong: rgba(126, 252, 242, 0.8);
-  --terminal-glow: rgba(57, 197, 187, 0.42);
-  --terminal-shadow: rgba(8, 230, 219, 0.12);
+  --terminal-border: rgba(57, 197, 187, 0.24);
+  --terminal-border-strong: rgba(126, 252, 242, 0.58);
+  --terminal-glow: rgba(57, 197, 187, 0.18);
+  --terminal-shadow: rgba(8, 230, 219, 0.08);
 }
 
 @theme inline {
@@ -34,12 +34,12 @@ html {
 body {
   min-height: 100vh;
   background:
-    radial-gradient(circle at top, rgba(57, 197, 187, 0.12), transparent 30%),
-    linear-gradient(180deg, #08101f 0%, #050816 55%, #03050d 100%);
+    radial-gradient(circle at top, rgba(57, 197, 187, 0.08), transparent 28%),
+    linear-gradient(180deg, #08101f 0%, #050816 58%, #03050d 100%);
   color: var(--terminal-fg);
-  font-family: var(--font-terminal), ui-monospace, SFMono-Regular, Menlo,
-    Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  text-shadow: 0 0 8px var(--terminal-glow);
+  font-family: var(--font-terminal), ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+  line-height: 1.55;
 }
 
 a {
@@ -49,7 +49,7 @@ a {
 }
 
 a:hover {
-  color: var(--terminal-amber);
+  color: var(--terminal-fg);
 }
 
 input,
@@ -66,44 +66,22 @@ textarea {
 input:focus,
 textarea:focus {
   border-color: var(--terminal-border-strong);
-  box-shadow: 0 0 0 1px var(--terminal-border-strong), 0 0 18px var(--terminal-shadow);
+  box-shadow: 0 0 0 1px var(--terminal-border-strong), 0 0 14px var(--terminal-shadow);
 }
 
 ::selection {
-  background: var(--terminal-fg);
+  background: var(--terminal-accent);
   color: #041014;
 }
 
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  background: repeating-linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 0.03) 0px,
-    rgba(255, 255, 255, 0.03) 1px,
-    transparent 2px,
-    transparent 4px
-  );
-  pointer-events: none;
-  mix-blend-mode: soft-light;
-  opacity: 0.22;
-  z-index: 1;
-}
-
-main,
-section,
-article,
-header,
-footer {
-  position: relative;
-  z-index: 2;
+.site-shell {
+  min-height: 100vh;
 }
 
 .terminal-shell {
   border: 1px solid var(--terminal-border);
-  background: linear-gradient(180deg, rgba(10, 16, 32, 0.95), rgba(5, 8, 22, 0.96));
-  box-shadow: 0 0 0 1px rgba(57, 197, 187, 0.08), inset 0 0 24px rgba(57, 197, 187, 0.05);
+  background: linear-gradient(180deg, rgba(10, 16, 32, 0.94), rgba(5, 8, 22, 0.96));
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
 }
 
 .terminal-titlebar {
@@ -115,52 +93,52 @@ footer {
   padding: 0.75rem 1rem;
   color: var(--terminal-muted);
   font-size: 0.75rem;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .terminal-frame {
   border: 1px solid var(--terminal-border);
-  background: linear-gradient(180deg, rgba(9, 15, 31, 0.94), rgba(5, 8, 22, 0.96));
-  box-shadow: inset 0 0 20px rgba(57, 197, 187, 0.05);
+  background: linear-gradient(180deg, rgba(9, 15, 31, 0.92), rgba(5, 8, 22, 0.95));
 }
 
 .terminal-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 1px solid var(--terminal-border-strong);
   color: var(--terminal-fg);
-  background: rgba(57, 197, 187, 0.06);
-  padding: 0.5rem 1rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  background: rgba(57, 197, 187, 0.08);
+  padding: 0.7rem 1rem;
+  font-size: 0.875rem;
+  letter-spacing: 0.02em;
 }
 
 .terminal-button:hover {
-  background: var(--terminal-fg);
-  color: #041014;
+  background: rgba(57, 197, 187, 0.16);
 }
 
 .terminal-chip {
   border: 1px solid var(--terminal-border);
-  padding: 0.35rem 0.75rem;
+  padding: 0.35rem 0.7rem;
   font-size: 0.75rem;
   color: var(--terminal-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  background: rgba(57, 197, 187, 0.03);
+  letter-spacing: 0.02em;
+  background: rgba(57, 197, 187, 0.04);
 }
 
 .terminal-chip[data-active="true"] {
   border-color: var(--terminal-border-strong);
   color: var(--terminal-fg);
-  box-shadow: inset 0 0 12px rgba(57, 197, 187, 0.08);
+  background: rgba(57, 197, 187, 0.1);
 }
 
-.cursor-blink {
-  animation: blink 1s steps(2, start) infinite;
+.nav-link {
+  border: 1px solid transparent;
+  padding: 0.45rem 0.75rem;
 }
 
-@keyframes blink {
-  to {
-    opacity: 0;
-  }
+.nav-link:hover {
+  border-color: var(--terminal-border);
+  background: rgba(57, 197, 187, 0.05);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -18,42 +19,45 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="ko">
       <body className={`${jetbrainsMono.variable} antialiased`}>
-        <div className="relative z-2 border-b border-[var(--terminal-border)] bg-[rgba(5,8,22,0.82)] backdrop-blur-sm">
-          <div className="mx-auto flex max-w-6xl flex-col gap-3 px-4 py-4 sm:px-6 md:flex-row md:items-center md:justify-between">
-            <div>
-              <p className="text-xs uppercase tracking-[0.28em] text-[var(--terminal-accent)]">
-                Voxie // Miku Console
-              </p>
-              <p className="mt-1 text-xs text-[var(--terminal-muted)]">
-                vocaloid archive interface [online]
-              </p>
+        <div className="site-shell">
+          <header className="border-b border-[var(--terminal-border)] bg-[rgba(5,8,22,0.88)] backdrop-blur-sm">
+            <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 sm:px-6 md:flex-row md:items-center md:justify-between">
+              <div>
+                <Link href="/" className="text-lg font-semibold text-[var(--terminal-fg)] hover:text-[var(--terminal-fg)]">
+                  Voxie
+                </Link>
+                <p className="mt-1 text-sm text-[var(--terminal-muted)]">
+                  보컬로이드 카드를 모으고 덱으로 정리하는 아카이브
+                </p>
+              </div>
+
+              <nav className="flex flex-wrap items-center gap-2 text-sm text-[var(--terminal-soft)]">
+                <Link className="nav-link" href="/">
+                  카드
+                </Link>
+                <Link className="nav-link" href="/decks">
+                  덱
+                </Link>
+                <Link className="nav-link" href="/cards/new">
+                  카드 추가
+                </Link>
+                <Link className="nav-link" href="/decks/new">
+                  덱 추가
+                </Link>
+              </nav>
             </div>
-            <nav className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.14em] text-[var(--terminal-muted)]">
-              <a className="terminal-chip" href="/">
-                cards
-              </a>
-              <a className="terminal-chip" href="/decks">
-                decks
-              </a>
-              <a className="terminal-chip" href="/cards/new">
-                create-card
-              </a>
-              <a className="terminal-chip" href="/decks/new">
-                create-deck
-              </a>
-            </nav>
-          </div>
+          </header>
+
+          {children}
+
+          <footer className="mx-auto max-w-6xl px-4 pb-8 pt-2 text-sm text-[var(--terminal-muted)] sm:px-6">
+            <div className="border-t border-[var(--terminal-border)] pt-4">
+              Voxie archive · cards / decks / notes
+            </div>
+          </footer>
         </div>
-
-        {children}
-
-        <footer className="mx-auto max-w-6xl px-4 pb-8 pt-2 text-xs uppercase tracking-[0.14em] text-[var(--terminal-muted)] sm:px-6">
-          <div className="border-t border-[var(--terminal-border)] pt-4">
-            voxie://archive ready · theme=miku-phosphor · status [stable]
-          </div>
-        </footer>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,125 +18,30 @@ export default async function Home({ searchParams }: Props) {
   );
   const tags = listTags(allCards);
   const featuredDecks = allDecks.filter((deck) => deck.featured).slice(0, 3);
-  const highlightedCards = allCards.slice(0, 4);
 
   return (
     <div className="min-h-screen text-white">
-      <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-12">
-        <header className="terminal-shell overflow-hidden">
-          <div className="terminal-titlebar">
-            <span>voxie://archive</span>
-            <span>status [live]</span>
-          </div>
-          <div className="grid gap-8 px-5 py-6 sm:px-8 sm:py-8 md:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)] md:items-start">
-            <div>
-              <p className="text-xs uppercase tracking-[0.3em] text-[var(--terminal-accent)]">
-                vocaloid archive interface
-              </p>
-              <h1 className="mt-4 text-4xl font-semibold leading-tight sm:text-5xl">
-                보컬로이드 곡과 모먼트를 카드로 모으고, 덱으로 큐레이션하는 아카이브
-              </h1>
-              <p className="mt-4 max-w-2xl text-sm leading-7 text-[var(--terminal-soft)] sm:text-base">
-                좋아하는 곡, 장면, 감정선, 해석을 카드로 남기고 테마별 덱으로 묶어보세요.
-                Voxie는 단순 목록이 아니라 왜 이 곡을 기억하는지까지 쌓아가는 커뮤니티형 컬렉션을 목표로 합니다.
-              </p>
-              <div className="mt-6 flex flex-wrap gap-3 text-sm">
-                <Link className="terminal-button" href="#cards">
-                  [ 카드 둘러보기 ]
-                </Link>
-                <Link className="terminal-button" href="#featured-decks">
-                  [ 예시 덱 보기 ]
-                </Link>
+      <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
+        <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+          <div className="terminal-shell p-5 sm:p-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <h1 className="text-2xl font-semibold sm:text-3xl">카드 아카이브</h1>
+                <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">
+                  곡, 장면, 감정선을 카드로 남기고 덱으로 묶어 정리합니다.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
                 <Link className="terminal-button" href="/cards/new">
-                  [ 카드 작성 ]
+                  카드 추가
+                </Link>
+                <Link className="terminal-button" href="/decks/new">
+                  덱 추가
                 </Link>
               </div>
             </div>
 
-            <aside className="terminal-frame p-4 sm:p-5">
-              <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.18em] text-[var(--terminal-muted)]">
-                <span>signal</span>
-                <span>{cards.length.toString().padStart(2, "0")} visible</span>
-              </div>
-              <div className="mt-4 grid gap-3 text-sm sm:grid-cols-3 md:grid-cols-1">
-                <div className="border border-[var(--terminal-border)] px-3 py-3">
-                  <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--terminal-muted)]">cards</p>
-                  <p className="mt-2 text-2xl font-semibold text-[var(--terminal-fg)]">{allCards.length}</p>
-                  <p className="mt-1 text-xs text-[var(--terminal-muted)]">곡/모먼트 기록</p>
-                </div>
-                <div className="border border-[var(--terminal-border)] px-3 py-3">
-                  <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--terminal-muted)]">decks</p>
-                  <p className="mt-2 text-2xl font-semibold text-[var(--terminal-fg)]">{allDecks.length}</p>
-                  <p className="mt-1 text-xs text-[var(--terminal-muted)]">큐레이션 묶음</p>
-                </div>
-                <div className="border border-[var(--terminal-border)] px-3 py-3">
-                  <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--terminal-muted)]">tags</p>
-                  <p className="mt-2 text-2xl font-semibold text-[var(--terminal-fg)]">{tags.length}</p>
-                  <p className="mt-1 text-xs text-[var(--terminal-muted)]">탐색 포인트</p>
-                </div>
-              </div>
-            </aside>
-          </div>
-        </header>
-
-        <section className="mt-8 grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
-          <article className="terminal-frame p-5 sm:p-6">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">cards → decks → archive</p>
-            <div className="mt-4 grid gap-4 sm:grid-cols-3">
-              <div>
-                <p className="font-semibold text-[var(--terminal-fg)]">1. 카드</p>
-                <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">
-                  곡, 장면, 감정 포인트를 하나의 기록 단위로 남깁니다.
-                </p>
-              </div>
-              <div>
-                <p className="font-semibold text-[var(--terminal-fg)]">2. 덱</p>
-                <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">
-                  같은 시대, 프로듀서, 분위기의 카드를 맥락으로 묶습니다.
-                </p>
-              </div>
-              <div>
-                <p className="font-semibold text-[var(--terminal-fg)]">3. 아카이브</p>
-                <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">
-                  단순 DB가 아니라 왜 기억되는지까지 읽히는 컬렉션을 만듭니다.
-                </p>
-              </div>
-            </div>
-          </article>
-
-          <article id="featured-decks" className="terminal-frame p-5 sm:p-6">
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">featured decks</p>
-                <h2 className="mt-2 text-xl font-semibold">덱이 왜 필요한지 먼저 보여주기</h2>
-              </div>
-              <Link className="text-sm text-[var(--terminal-fg)]" href="/decks">
-                전체 덱 보기 →
-              </Link>
-            </div>
-            <div className="mt-4 space-y-3">
-              {featuredDecks.map((deck) => (
-                <Link key={deck.slug} href={`/decks/${deck.slug}`} className="block border border-[var(--terminal-border)] px-4 py-4">
-                  <div className="flex items-center justify-between gap-4 text-xs uppercase tracking-[0.14em] text-[var(--terminal-muted)]">
-                    <span>{deck.name}</span>
-                    <span>{deck.cards.length} cards</span>
-                  </div>
-                  <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">
-                    {deck.shortPitch ?? deck.description}
-                  </p>
-                </Link>
-              ))}
-            </div>
-          </article>
-        </section>
-
-        <section className="mt-8 terminal-shell overflow-hidden">
-          <div className="terminal-titlebar">
-            <span>filter --cards</span>
-            <span>{tag ? `tag:${tag}` : "tag:*"}</span>
-          </div>
-          <div className="space-y-4 px-5 py-5 sm:px-6">
-            <form action="/" className="flex flex-col gap-3 sm:flex-row">
+            <form action="/" className="mt-6 flex flex-col gap-3 sm:flex-row">
               <input
                 type="text"
                 name="q"
@@ -144,19 +49,19 @@ export default async function Home({ searchParams }: Props) {
                 placeholder="곡, 캐릭터, 프로듀서 검색"
                 className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
               />
-              <button type="submit" className="terminal-button sm:min-w-36">
-                [ 검색 ]
+              <button type="submit" className="terminal-button sm:min-w-32">
+                검색
               </button>
             </form>
 
-            <div className="flex flex-wrap gap-2">
+            <div className="mt-4 flex flex-wrap gap-2">
               <Link
                 href={query ? `/?q=${encodeURIComponent(query)}` : "/"}
                 data-testid="tag-all"
                 data-active={!tag}
                 className="terminal-chip"
               >
-                all
+                전체
               </Link>
               {tags.map((item) => (
                 <Link
@@ -171,73 +76,112 @@ export default async function Home({ searchParams }: Props) {
               ))}
             </div>
           </div>
+
+          <aside className="grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
+            <div className="terminal-frame p-4">
+              <p className="text-xs text-[var(--terminal-muted)]">카드</p>
+              <p className="mt-2 text-2xl font-semibold">{allCards.length}</p>
+            </div>
+            <div className="terminal-frame p-4">
+              <p className="text-xs text-[var(--terminal-muted)]">덱</p>
+              <p className="mt-2 text-2xl font-semibold">{allDecks.length}</p>
+            </div>
+            <div className="terminal-frame p-4">
+              <p className="text-xs text-[var(--terminal-muted)]">태그</p>
+              <p className="mt-2 text-2xl font-semibold">{tags.length}</p>
+            </div>
+          </aside>
         </section>
 
-        <section id="cards" className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {cards.length === 0 ? (
-            <article className="terminal-shell px-6 py-10 md:col-span-2 xl:col-span-3">
-              <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">
-                no results detected
-              </p>
-              <h2 className="mt-3 text-2xl font-semibold">검색 결과가 없어요</h2>
-              <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--terminal-muted)]">
-                다른 태그를 선택하거나 검색어를 줄여보세요. 필요하면 새 카드를 바로 추가해서
-                아카이브를 채울 수도 있어요.
-              </p>
-              <div className="mt-6 flex flex-wrap gap-3">
-                <Link className="terminal-button" href={tag ? "/" : "/cards/new"}>
-                  {tag ? "[ 필터 초기화 ]" : "[ 카드 작성 ]"}
-                </Link>
+        {featuredDecks.length > 0 && (
+          <section className="mt-8">
+            <div className="mb-4 flex items-center justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-semibold">추천 덱</h2>
+                <p className="mt-1 text-sm text-[var(--terminal-muted)]">
+                  지금 바로 둘러볼 수 있는 큐레이션 묶음
+                </p>
               </div>
-            </article>
-          ) : (
-            cards.map((card) => (
-              <article key={card.slug} data-testid="card" className="terminal-frame p-5">
-                <div className="flex items-center justify-between text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)]">
-                  <span>{card.character}</span>
-                  <span>{card.type}</span>
-                </div>
-                <h2 className="mt-3 text-lg font-semibold">
-                  <Link className="hover:text-[var(--terminal-fg)]" href={`/cards/${card.slug}`}>
-                    {card.title}
-                  </Link>
-                </h2>
-                {card.summary && (
-                  <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">{card.summary}</p>
-                )}
-                <div className="mt-3 flex flex-wrap gap-2 text-xs text-[var(--terminal-muted)]">
-                  {card.producer && <span>Producer: {card.producer}</span>}
-                  {card.year && <span>Year: {card.year}</span>}
-                </div>
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {card.tags.map((item) => (
-                    <span key={item} className="terminal-chip">
-                      #{item}
-                    </span>
-                  ))}
-                </div>
-              </article>
-            ))
-          )}
-        </section>
+              <Link className="text-sm text-[var(--terminal-soft)]" href="/decks">
+                전체 덱 보기 →
+              </Link>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {featuredDecks.map((deck) => (
+                <Link key={deck.slug} href={`/decks/${deck.slug}`} className="terminal-frame block p-5">
+                  <div className="flex items-center justify-between gap-4 text-xs text-[var(--terminal-muted)]">
+                    <span>{deck.name}</span>
+                    <span>{deck.cards.length} cards</span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-[var(--terminal-soft)]">
+                    {deck.shortPitch ?? deck.description}
+                  </p>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {deck.tags.slice(0, 3).map((item) => (
+                      <span key={item} className="terminal-chip">
+                        #{item}
+                      </span>
+                    ))}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
 
-        <section className="mt-8">
+        <section id="cards" className="mt-8">
           <div className="mb-4 flex items-center justify-between gap-4">
             <div>
-              <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-accent)]">highlight cards</p>
-              <h2 className="mt-2 text-xl font-semibold">대표 카드만 봐도 서비스 목적이 보이도록</h2>
+              <h2 className="text-lg font-semibold">카드</h2>
+              <p className="mt-1 text-sm text-[var(--terminal-muted)]">
+                {query || tag ? "필터 결과" : "최근 카드와 대표 카드 목록"}
+              </p>
             </div>
+            <Link className="text-sm text-[var(--terminal-soft)]" href="/cards/new">
+              카드 추가 →
+            </Link>
           </div>
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-            {highlightedCards.map((card) => (
-              <Link key={card.slug} href={`/cards/${card.slug}`} className="terminal-frame block p-4">
-                <p className="text-xs uppercase tracking-[0.18em] text-[var(--terminal-soft)]">
-                  {card.year ?? "archive"}
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {cards.length === 0 ? (
+              <article className="terminal-shell px-6 py-10 md:col-span-2 xl:col-span-3">
+                <h2 className="text-xl font-semibold">검색 결과가 없어요</h2>
+                <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--terminal-muted)]">
+                  다른 태그를 선택하거나 검색어를 줄여보세요. 필요하면 새 카드를 추가해 아카이브를 채울 수 있어요.
                 </p>
-                <p className="mt-8 text-lg font-semibold">{card.title}</p>
-                <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">{card.summary}</p>
-              </Link>
-            ))}
+                <div className="mt-6 flex flex-wrap gap-3">
+                  <Link className="terminal-button" href={tag ? "/" : "/cards/new"}>
+                    {tag ? "필터 초기화" : "카드 추가"}
+                  </Link>
+                </div>
+              </article>
+            ) : (
+              cards.map((card) => (
+                <article key={card.slug} data-testid="card" className="terminal-frame p-5">
+                  <div className="flex items-center justify-between text-xs text-[var(--terminal-muted)]">
+                    <span>{card.character}</span>
+                    <span>{card.type}</span>
+                  </div>
+                  <h3 className="mt-3 text-lg font-semibold">
+                    <Link href={`/cards/${card.slug}`}>{card.title}</Link>
+                  </h3>
+                  {card.summary && (
+                    <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">{card.summary}</p>
+                  )}
+                  <div className="mt-3 flex flex-wrap gap-3 text-xs text-[var(--terminal-muted)]">
+                    {card.producer && <span>{card.producer}</span>}
+                    {card.year && <span>{card.year}</span>}
+                  </div>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {card.tags.map((item) => (
+                      <span key={item} className="terminal-chip">
+                        #{item}
+                      </span>
+                    ))}
+                  </div>
+                </article>
+              ))
+            )}
           </div>
         </section>
       </main>


### PR DESCRIPTION
## 변경 사항
- 홈 화면의 과한 히어로/홍보 영역을 줄이고 카드 탐색과 추가 흐름이 먼저 보이도록 재구성했습니다.
- 카드/덱 상세의 기술적이고 소개성 강한 카피를 줄이고 실제 서비스 정보 위주로 정리했습니다.
- 전역 스타일을 정리해 폰트/톤을 더 일관되게 맞추고 과한 CRT/글로우 느낌을 완화했습니다.
- 상단 네비게이션과 액션 버튼을 앱형 UI에 맞게 단순화했습니다.

## 테스트
- pnpm typecheck
- pnpm test