### PR TITLE
feat(mobile): improve touch targets and empty states

### DIFF
--- a/src/app/cards/new/page.tsx
+++ b/src/app/cards/new/page.tsx
@@ -91,7 +91,7 @@ export default function CardCreatePage() {
           </div>
         </header>
 
-        <form onSubmit={onSubmit} className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_280px]">
+        <form onSubmit={onSubmit} className="mt-8 grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px] lg:gap-6">
           <div className="terminal-frame space-y-6 p-5 sm:p-6">
             <section>
               <h2 className="text-lg font-semibold">기본 정보</h2>
@@ -177,15 +177,15 @@ export default function CardCreatePage() {
               </div>
             </section>
 
-            <div className="flex flex-wrap items-center gap-3 border-t border-[var(--terminal-border)] pt-6">
+            <div className="flex flex-col gap-3 border-t border-[var(--terminal-border)] pt-6 sm:flex-row sm:flex-wrap sm:items-center">
               <button
                 type="submit"
-                className="terminal-button disabled:opacity-50"
+                className="terminal-button w-full disabled:opacity-50 sm:w-auto"
                 disabled={isSubmitting}
               >
                 {isSubmitting ? "저장 중..." : "카드 저장"}
               </button>
-              <Link className="terminal-button" href="/">
+              <Link className="terminal-button w-full sm:w-auto" href="/">
                 취소
               </Link>
             </div>

--- a/src/app/decks/[slug]/edit/DeckEditClient.tsx
+++ b/src/app/decks/[slug]/edit/DeckEditClient.tsx
@@ -167,7 +167,7 @@ export default function DeckEditClient({ deck, cards }: Props) {
                         )
                       }
                       data-active={active}
-                      className="terminal-chip"
+                      className="terminal-chip min-h-11"
                     >
                       #{tag}
                     </button>
@@ -197,7 +197,8 @@ export default function DeckEditClient({ deck, cards }: Props) {
                   {filteredCards.map((card) => (
                     <label
                       key={card.slug}
-                      className="flex items-start gap-3 border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm"
+                      data-active={selectedCards.includes(card.slug)}
+                      className="terminal-selectable flex items-start gap-3 border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm"
                     >
                       <input
                         type="checkbox"
@@ -216,7 +217,9 @@ export default function DeckEditClient({ deck, cards }: Props) {
                   ))}
                 </div>
                 {filteredCards.length === 0 && (
-                  <p className="text-sm text-[var(--terminal-muted)]">검색 결과에 맞는 카드가 없어요.</p>
+                  <div className="border border-[var(--terminal-border)] px-4 py-4 text-sm text-[var(--terminal-muted)]">
+                    검색 결과에 맞는 카드가 없어요. 다른 키워드로 다시 찾거나, 카드 목록을 먼저 늘린 뒤 다시 선택해보세요.
+                  </div>
                 )}
                 {errors.includes("cards") && (
                   <p className="text-xs text-[var(--terminal-error)]">카드를 최소 1개 선택해줘.</p>
@@ -224,15 +227,15 @@ export default function DeckEditClient({ deck, cards }: Props) {
               </div>
             </section>
 
-            <div className="flex flex-wrap items-center gap-3 border-t border-[var(--terminal-border)] pt-6">
+            <div className="flex flex-col gap-3 border-t border-[var(--terminal-border)] pt-6 sm:flex-row sm:flex-wrap sm:items-center">
               <button
                 type="submit"
-                className="terminal-button disabled:opacity-50"
+                className="terminal-button w-full disabled:opacity-50 sm:w-auto"
                 disabled={isSubmitting}
               >
                 {isSubmitting ? "저장 중..." : "변경사항 저장"}
               </button>
-              <Link className="terminal-button" href={`/decks/${deck.slug}`}>
+              <Link className="terminal-button w-full sm:w-auto" href={`/decks/${deck.slug}`}>
                 취소
               </Link>
             </div>

--- a/src/app/decks/new/DeckCreateClient.tsx
+++ b/src/app/decks/new/DeckCreateClient.tsx
@@ -181,7 +181,8 @@ export default function DeckCreateClient({ cards }: Props) {
                   {filteredCards.map((card) => (
                     <label
                       key={card.slug}
-                      className="flex items-start gap-3 border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm"
+                      data-active={form.cards.includes(card.slug)}
+                      className="terminal-selectable flex items-start gap-3 border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm"
                     >
                       <input
                         type="checkbox"
@@ -200,7 +201,9 @@ export default function DeckCreateClient({ cards }: Props) {
                   ))}
                 </div>
                 {filteredCards.length === 0 && (
-                  <p className="text-sm text-[var(--terminal-muted)]">검색 결과에 맞는 카드가 없어요.</p>
+                  <div className="border border-[var(--terminal-border)] px-4 py-4 text-sm text-[var(--terminal-muted)]">
+                    검색 결과에 맞는 카드가 없어요. 다른 키워드로 다시 찾거나, 먼저 카드를 추가한 뒤 덱으로 묶어보세요.
+                  </div>
                 )}
                 {errors.includes("cards") && (
                   <p className="text-xs text-[var(--terminal-error)]">카드를 최소 1개 선택해줘.</p>
@@ -208,15 +211,15 @@ export default function DeckCreateClient({ cards }: Props) {
               </div>
             </section>
 
-            <div className="flex flex-wrap items-center gap-3 border-t border-[var(--terminal-border)] pt-6">
+            <div className="flex flex-col gap-3 border-t border-[var(--terminal-border)] pt-6 sm:flex-row sm:flex-wrap sm:items-center">
               <button
                 type="submit"
-                className="terminal-button disabled:opacity-50"
+                className="terminal-button w-full disabled:opacity-50 sm:w-auto"
                 disabled={isSubmitting}
               >
                 {isSubmitting ? "저장 중..." : "덱 저장"}
               </button>
-              <Link className="terminal-button" href="/decks">
+              <Link className="terminal-button w-full sm:w-auto" href="/decks">
                 취소
               </Link>
             </div>

--- a/src/app/decks/page.tsx
+++ b/src/app/decks/page.tsx
@@ -22,11 +22,11 @@ export default async function DeckListPage({
                 카드들을 테마와 맥락으로 묶은 컬렉션 목록입니다.
               </p>
             </div>
-            <div className="flex flex-wrap gap-2">
-              <Link className="terminal-button" href="/decks/new">
+            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap">
+              <Link className="terminal-button w-full sm:w-auto" href="/decks/new">
                 덱 추가
               </Link>
-              <Link className="terminal-button" href="/">
+              <Link className="terminal-button w-full sm:w-auto" href="/">
                 카드 보기
               </Link>
             </div>
@@ -40,43 +40,57 @@ export default async function DeckListPage({
               placeholder="덱 이름, 설명, 태그 검색"
               className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
             />
-            <button type="submit" className="terminal-button sm:min-w-32">
+            <button type="submit" className="terminal-button w-full sm:min-w-32 sm:w-auto">
               검색
             </button>
           </form>
         </header>
 
-        <section className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <section className="mt-8 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
           {decks.length === 0 ? (
             <article className="terminal-shell px-6 py-10 md:col-span-2 xl:col-span-3">
-              <h2 className="text-xl font-semibold">아직 덱이 없어요</h2>
+              <h2 className="text-xl font-semibold">{query ? "검색된 덱이 없어요" : "아직 덱이 없어요"}</h2>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--terminal-muted)]">
-                첫 덱을 만들면 카드들을 테마별로 정리해서 볼 수 있어요.
+                {query
+                  ? "검색어를 조금 줄이거나 다른 키워드로 다시 찾아보세요. 필요하면 새 덱을 바로 만들어 흐름을 정리할 수 있어요."
+                  : "첫 덱을 만들면 카드들을 테마별로 묶어서 더 빠르게 둘러볼 수 있어요."}
               </p>
-              <div className="mt-6">
-                <Link className="terminal-button" href="/decks/new">
+              <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+                <Link className="terminal-button w-full sm:w-auto" href="/decks/new">
                   덱 추가
                 </Link>
+                {query && (
+                  <Link className="terminal-button w-full sm:w-auto" href="/decks">
+                    검색 초기화
+                  </Link>
+                )}
               </div>
             </article>
           ) : (
             decks.map((deck) => (
-              <article key={deck.slug} className="terminal-frame p-5">
+              <article key={deck.slug} className="terminal-frame p-4 sm:p-5">
                 <div className="flex items-center justify-between text-xs text-[var(--terminal-muted)]">
                   <span>{deck.cards.length} cards</span>
                   <span>{deck.featured ? "featured" : "deck"}</span>
                 </div>
-                <h2 className="mt-3 text-lg font-semibold">
-                  <Link href={`/decks/${deck.slug}`}>{deck.name}</Link>
-                </h2>
-                <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">
-                  {deck.shortPitch ?? deck.description}
-                </p>
+                <div className="mt-3 flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <h2 className="truncate text-base font-semibold sm:text-lg">
+                      <Link href={`/decks/${deck.slug}`}>{deck.name}</Link>
+                    </h2>
+                    <p className="mt-2 line-clamp-2 text-sm leading-6 text-[var(--terminal-soft)]">
+                      {deck.shortPitch ?? deck.description}
+                    </p>
+                  </div>
+                  <Link href={`/decks/${deck.slug}`} className="shrink-0 text-sm text-[var(--terminal-soft)]">
+                    보기 →
+                  </Link>
+                </div>
                 {deck.description && deck.shortPitch && (
-                  <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">{deck.description}</p>
+                  <p className="mt-2 line-clamp-2 text-sm leading-6 text-[var(--terminal-muted)]">{deck.description}</p>
                 )}
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {deck.tags.map((tag) => (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {deck.tags.slice(0, 4).map((tag) => (
                     <span key={tag} className="terminal-chip">
                       #{tag}
                     </span>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -63,6 +63,17 @@ input,
 textarea,
 select {
   outline: none;
+  border-radius: 0;
+}
+
+input,
+textarea,
+select,
+button,
+a.terminal-button,
+label.terminal-selectable,
+button.terminal-chip {
+  -webkit-tap-highlight-color: transparent;
 }
 
 input:focus,
@@ -107,6 +118,7 @@ select:focus {
 
 .terminal-button {
   display: inline-flex;
+  min-height: 44px;
   align-items: center;
   justify-content: center;
   border: 1px solid var(--terminal-border-strong);
@@ -123,7 +135,7 @@ select:focus {
 
 .terminal-chip {
   border: 1px solid var(--terminal-border);
-  padding: 0.35rem 0.7rem;
+  padding: 0.45rem 0.75rem;
   font-size: 0.75rem;
   color: var(--terminal-muted);
   letter-spacing: 0.01em;
@@ -136,9 +148,19 @@ select:focus {
   background: rgba(57, 197, 187, 0.1);
 }
 
+.terminal-selectable {
+  min-height: 56px;
+  transition: border-color 160ms ease, background-color 160ms ease;
+}
+
+.terminal-selectable[data-active="true"] {
+  border-color: var(--terminal-border-strong);
+  background: rgba(57, 197, 187, 0.08);
+}
+
 .nav-link {
   border: 1px solid transparent;
-  padding: 0.45rem 0.75rem;
+  padding: 0.6rem 0.8rem;
 }
 
 .nav-link:hover {


### PR DESCRIPTION
## 🎵 변경 사항
- 모바일에서 버튼/탭/선택 카드의 터치 영역을 더 넓게 조정
- 카드/덱 작성 폼의 액션 버튼을 모바일에서 full width로 정리
- 덱 목록과 카드 선택 영역의 빈 상태 문구와 복귀 동선을 보강
- 덱 카드 선택 UI에 active state를 더 명확하게 추가

## 🎤 동기 / 맥락
이전 PR에서 서비스형 구조와 폰트 안정화를 마친 뒤, 실제 모바일 사용감에서 가장 먼저 체감되는 터치 영역과 빈 상태 UX를 보완했습니다.

## 🎹 테스트
- [x] `pnpm typecheck`
- [x] `pnpm test`

## ✅ 체크리스트
- [x] 코드가 프로젝트 스타일 가이드를 따름
- [x] self-review 완료
- [x] 파괴적 변경 없음
