### PR TITLE
feat(ui): refine archive detail hierarchy and search flow

### DIFF
--- a/src/app/cards/[slug]/page.tsx
+++ b/src/app/cards/[slug]/page.tsx
@@ -36,7 +36,7 @@ export default async function CardDetail({ params }: Props) {
           <Link className="text-sm text-[var(--terminal-muted)]" href="/">
             ← 카드 목록
           </Link>
-          <div className="mt-4 grid gap-6 md:grid-cols-[minmax(0,1fr)_280px]">
+          <div className="mt-4 grid gap-4 md:grid-cols-[minmax(0,1fr)_280px] md:gap-6">
             <div>
               <div className="dense-meta">
                 <span>{card.character}</span>
@@ -57,13 +57,18 @@ export default async function CardDetail({ params }: Props) {
                   </span>
                 ))}
               </div>
-              <div className="mt-5 flex flex-wrap gap-2">
+              <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
                 {relatedDecks.length > 0 && (
-                  <Link className="terminal-button" href={`/decks/${relatedDecks[0].slug}`}>
+                  <Link className="terminal-button w-full sm:w-auto" href={`/decks/${relatedDecks[0].slug}`}>
                     관련 덱 보기
                   </Link>
                 )}
-                <a href={links.youtubeSearch} target="_blank" rel="noreferrer" className="terminal-button">
+                <a
+                  href={links.youtubeSearch}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="terminal-button w-full sm:w-auto"
+                >
                   YouTube 검색
                 </a>
               </div>
@@ -94,6 +99,10 @@ export default async function CardDetail({ params }: Props) {
                     <span className="text-right">{card.era}</span>
                   </div>
                 )}
+                <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
+                  <span className="text-[var(--terminal-muted)]">연결된 덱</span>
+                  <span>{relatedDecks.length}</span>
+                </div>
               </div>
             </aside>
           </div>
@@ -160,14 +169,19 @@ export default async function CardDetail({ params }: Props) {
                 {relatedDecks.length > 0 ? (
                   relatedDecks.map((deck) => (
                     <Link key={deck.slug} href={`/decks/${deck.slug}`} className="block border border-[var(--terminal-border)] px-4 py-4">
-                      <p className="text-sm font-semibold">{deck.name}</p>
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-sm font-semibold">{deck.name}</p>
+                        <span className="text-xs text-[var(--terminal-muted)]">{deck.cards.length} cards</span>
+                      </div>
                       <p className="mt-1 text-sm leading-6 text-[var(--terminal-muted)]">
                         {deck.shortPitch ?? deck.description}
                       </p>
                     </Link>
                   ))
                 ) : (
-                  <p className="text-sm text-[var(--terminal-muted)]">아직 이 카드를 담은 덱이 없어요.</p>
+                  <div className="border border-[var(--terminal-border)] px-4 py-4 text-sm text-[var(--terminal-muted)]">
+                    아직 이 카드를 담은 덱이 없어요. 덱을 새로 만들어 이 카드를 중심으로 묶을 수 있어요.
+                  </div>
                 )}
               </div>
             </section>

--- a/src/app/decks/[slug]/page.tsx
+++ b/src/app/decks/[slug]/page.tsx
@@ -31,21 +31,21 @@ export default async function DeckDetailPage({ params }: Props) {
     <div className="min-h-screen text-white">
       <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 sm:py-10">
         <header className="terminal-shell p-5 sm:p-6">
-          <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
             <Link className="text-sm text-[var(--terminal-muted)]" href="/decks">
               ← 덱 목록
             </Link>
-            <div className="flex flex-wrap gap-2">
-              <Link className="terminal-button" href={`/decks/${deck.slug}/edit`}>
+            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap">
+              <Link className="terminal-button w-full sm:w-auto" href={`/decks/${deck.slug}/edit`}>
                 덱 수정
               </Link>
-              <Link className="terminal-button" href="/cards/new">
+              <Link className="terminal-button w-full sm:w-auto" href="/cards/new">
                 카드 추가
               </Link>
             </div>
           </div>
 
-          <div className="mt-4 grid gap-6 md:grid-cols-[minmax(0,1fr)_260px]">
+          <div className="mt-4 grid gap-4 md:grid-cols-[minmax(0,1fr)_260px] md:gap-6">
             <div>
               <div className="dense-meta">
                 <span>{cards.length} cards</span>
@@ -114,7 +114,10 @@ export default async function DeckDetailPage({ params }: Props) {
             <div className="mt-4 space-y-3">
               {cards.slice(0, 3).map((card) => (
                 <div key={card?.slug} className="border border-[var(--terminal-border)] px-4 py-4">
-                  <p className="text-sm font-semibold text-[var(--terminal-fg)]">{card?.title}</p>
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-semibold text-[var(--terminal-fg)]">{card?.title}</p>
+                    <span className="text-xs uppercase text-[var(--terminal-muted)]">{card?.type}</span>
+                  </div>
                   <p className="mt-1 text-sm leading-6 text-[var(--terminal-muted)]">{card?.summary}</p>
                 </div>
               ))}
@@ -139,16 +142,16 @@ export default async function DeckDetailPage({ params }: Props) {
                 <span className="truncate">{card?.character}</span>
                 <span className="shrink-0 uppercase">{card?.type}</span>
               </div>
-              <div className="mt-3 flex items-start justify-between gap-4">
-                <div className="min-w-0">
-                  <Link className="block truncate text-base font-semibold sm:text-lg" href={`/cards/${card?.slug}`}>
-                    {card?.title}
-                  </Link>
-                  {card?.summary && <p className="mt-2 line-clamp-2 text-sm leading-6 text-[var(--terminal-soft)]">{card.summary}</p>}
-                </div>
-                <Link className="shrink-0 text-sm text-[var(--terminal-soft)]" href={`/cards/${card?.slug}`}>
-                  보기 →
+              <div className="mt-3 min-w-0">
+                <Link className="block truncate text-base font-semibold sm:text-lg" href={`/cards/${card?.slug}`}>
+                  {card?.title}
                 </Link>
+                {card?.summary && <p className="mt-2 line-clamp-2 text-sm leading-6 text-[var(--terminal-soft)]">{card.summary}</p>}
+              </div>
+              <div className="dense-meta mt-3">
+                {card?.producer && <span>{card.producer}</span>}
+                {card?.year && <span>{card.year}</span>}
+                <span>{card?.tags.length ?? 0} tags</span>
               </div>
               <div className="mt-3 flex flex-wrap gap-2">
                 {card?.tags.slice(0, 4).map((tag) => (
@@ -156,6 +159,12 @@ export default async function DeckDetailPage({ params }: Props) {
                     #{tag}
                   </span>
                 ))}
+              </div>
+              <div className="mt-4 flex items-center justify-between gap-4 border-t border-[var(--terminal-border)] pt-3 text-sm">
+                <span className="text-[var(--terminal-muted)]">카드 상세 보기</span>
+                <Link className="text-[var(--terminal-soft)]" href={`/cards/${card?.slug}`}>
+                  열기 →
+                </Link>
               </div>
             </div>
           ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,17 +25,20 @@ export default async function Home({ searchParams }: Props) {
         <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
           <div className="terminal-shell p-5 sm:p-6">
             <div className="flex flex-wrap items-start justify-between gap-4">
-              <div>
-                <h1 className="text-2xl font-semibold sm:text-3xl">카드 아카이브</h1>
-                <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">
-                  곡, 장면, 감정선을 카드로 남기고 덱으로 묶어 정리합니다.
+              <div className="min-w-0">
+                <p className="text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)]">
+                  Voxie archive
+                </p>
+                <h1 className="mt-3 text-2xl font-semibold sm:text-3xl">카드 아카이브</h1>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-[var(--terminal-muted)]">
+                  곡, 장면, 감정선을 카드로 남기고 덱으로 묶어 정리합니다. 빠르게 추가하고, 나중에 큐레이션처럼 다시 엮을 수 있어요.
                 </p>
               </div>
-              <div className="flex flex-wrap gap-2">
-                <Link className="terminal-button" href="/cards/new">
+              <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap">
+                <Link className="terminal-button w-full sm:w-auto" href="/cards/new">
                   카드 추가
                 </Link>
-                <Link className="terminal-button" href="/decks/new">
+                <Link className="terminal-button w-full sm:w-auto" href="/decks/new">
                   덱 추가
                 </Link>
               </div>
@@ -49,10 +52,20 @@ export default async function Home({ searchParams }: Props) {
                 placeholder="곡, 캐릭터, 프로듀서 검색"
                 className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
               />
-              <button type="submit" className="terminal-button sm:min-w-32">
+              <button type="submit" className="terminal-button w-full sm:min-w-32 sm:w-auto">
                 검색
               </button>
             </form>
+
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--terminal-muted)]">
+              <span>{cards.length}개 표시 중</span>
+              {(query || tag) && <span>· 현재 필터 적용됨</span>}
+              {(query || tag) && (
+                <Link href="/" className="text-[var(--terminal-soft)] underline-offset-4 hover:underline">
+                  초기화
+                </Link>
+              )}
+            </div>
 
             <div className="mt-4 flex flex-wrap gap-2">
               <Link
@@ -77,7 +90,7 @@ export default async function Home({ searchParams }: Props) {
             </div>
           </div>
 
-          <aside className="grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
+          <aside className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
             <div className="terminal-frame p-4">
               <p className="text-xs text-[var(--terminal-muted)]">카드</p>
               <p className="mt-2 text-2xl font-semibold">{allCards.length}</p>
@@ -106,11 +119,11 @@ export default async function Home({ searchParams }: Props) {
                 전체 덱 보기 →
               </Link>
             </div>
-            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
               {featuredDecks.map((deck) => (
-                <Link key={deck.slug} href={`/decks/${deck.slug}`} className="terminal-frame block p-5">
+                <Link key={deck.slug} href={`/decks/${deck.slug}`} className="terminal-frame block p-4 sm:p-5">
                   <div className="flex items-center justify-between gap-4 text-xs text-[var(--terminal-muted)]">
-                    <span>{deck.name}</span>
+                    <span className="truncate">{deck.name}</span>
                     <span>{deck.cards.length} cards</span>
                   </div>
                   <p className="mt-3 line-clamp-2 text-sm leading-6 text-[var(--terminal-soft)]">
@@ -149,9 +162,12 @@ export default async function Home({ searchParams }: Props) {
                 <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--terminal-muted)]">
                   다른 태그를 선택하거나 검색어를 줄여보세요. 필요하면 새 카드를 추가해 아카이브를 채울 수 있어요.
                 </p>
-                <div className="mt-6 flex flex-wrap gap-3">
-                  <Link className="terminal-button" href={tag ? "/" : "/cards/new"}>
-                    {tag ? "필터 초기화" : "카드 추가"}
+                <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                  <Link className="terminal-button w-full sm:w-auto" href="/">
+                    필터 초기화
+                  </Link>
+                  <Link className="terminal-button w-full sm:w-auto" href="/cards/new">
+                    카드 추가
                   </Link>
                 </div>
               </article>
@@ -162,20 +178,15 @@ export default async function Home({ searchParams }: Props) {
                     <span className="truncate">{card.character}</span>
                     <span className="shrink-0 uppercase">{card.type}</span>
                   </div>
-                  <div className="mt-3 flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <h3 className="truncate text-base font-semibold sm:text-lg">
-                        <Link href={`/cards/${card.slug}`}>{card.title}</Link>
-                      </h3>
-                      {card.summary && (
-                        <p className="mt-2 line-clamp-2 text-sm leading-6 text-[var(--terminal-soft)]">
-                          {card.summary}
-                        </p>
-                      )}
-                    </div>
-                    <Link href={`/cards/${card.slug}`} className="shrink-0 text-sm text-[var(--terminal-soft)]">
-                      보기 →
-                    </Link>
+                  <div className="mt-3 min-w-0">
+                    <h3 className="truncate text-base font-semibold sm:text-lg">
+                      <Link href={`/cards/${card.slug}`}>{card.title}</Link>
+                    </h3>
+                    {card.summary && (
+                      <p className="mt-2 line-clamp-2 text-sm leading-6 text-[var(--terminal-soft)]">
+                        {card.summary}
+                      </p>
+                    )}
                   </div>
                   <div className="dense-meta mt-3">
                     {card.producer && <span>{card.producer}</span>}
@@ -188,6 +199,12 @@ export default async function Home({ searchParams }: Props) {
                         #{item}
                       </span>
                     ))}
+                  </div>
+                  <div className="mt-4 flex items-center justify-between gap-4 border-t border-[var(--terminal-border)] pt-3 text-sm">
+                    <span className="text-[var(--terminal-muted)]">상세 정보 보기</span>
+                    <Link href={`/cards/${card.slug}`} className="text-[var(--terminal-soft)]">
+                      열기 →
+                    </Link>
                   </div>
                 </article>
               ))


### PR DESCRIPTION
## 🎵 변경 사항
- 홈 화면 검색/필터 상태와 초기화 동선을 더 명확하게 정리
- 카드 목록 카드 하단 액션 구조를 추가해 서비스형 정보 흐름 강화
- 카드 상세 상단 정보 밀도와 관련 덱 빈 상태를 개선
- 덱 상세 상단 액션/미리보기/포함 카드 정보 계층을 홈과 일관되게 정리

## 🎤 동기 / 맥락
모바일 터치 영역과 빈 상태 UX를 정리한 다음 단계로, 홈/상세 화면에서 정보 우선순위와 탐색 흐름이 더 자연스럽게 느껴지도록 화면 구조를 다듬었습니다.

## 🎹 테스트
- [x] `pnpm typecheck`
- [x] `pnpm test`

## ✅ 체크리스트
- [x] 코드가 프로젝트 스타일 가이드를 따름
- [x] self-review 완료
- [x] 파괴적 변경 없음
