### PR TITLE
feat(ux): improve search feedback and creation flow

### DIFF
--- a/src/app/cards/new/page.tsx
+++ b/src/app/cards/new/page.tsx
@@ -53,7 +53,7 @@ export default function CardCreatePage() {
         const result = await createCard(payload);
 
         if (result.success) {
-          router.push("/");
+          router.push("/?created=card");
         } else {
           setSubmitError(result.error || "Failed to create card");
         }

--- a/src/app/decks/[slug]/page.tsx
+++ b/src/app/decks/[slug]/page.tsx
@@ -4,10 +4,13 @@ import { getCardBySlugAsync } from "@/lib/cards";
 
 type Props = {
   params: Promise<{ slug: string }>;
+  searchParams?: Promise<{ created?: string }>;
 };
 
-export default async function DeckDetailPage({ params }: Props) {
+export default async function DeckDetailPage({ params, searchParams }: Props) {
   const { slug } = await params;
+  const resolvedSearchParams = (await searchParams) ?? {};
+  const created = resolvedSearchParams.created;
   const deck = await getDeckBySlugAsync(slug);
 
   if (!deck) {
@@ -44,6 +47,12 @@ export default async function DeckDetailPage({ params }: Props) {
               </Link>
             </div>
           </div>
+
+          {created === "deck" && (
+            <div className="terminal-notice mt-5">
+              덱이 저장됐어요. 이제 카드 구성을 확인하거나 바로 수정해서 큐레이션을 더 다듬을 수 있어요.
+            </div>
+          )}
 
           <div className="mt-4 grid gap-4 md:grid-cols-[minmax(0,1fr)_260px] md:gap-6">
             <div>

--- a/src/app/decks/new/DeckCreateClient.tsx
+++ b/src/app/decks/new/DeckCreateClient.tsx
@@ -81,7 +81,7 @@ export default function DeckCreateClient({ cards }: Props) {
         const result = await createDeck(payload);
 
         if (result.success && result.data) {
-          router.push(`/decks/${result.data.slug}`);
+          router.push(`/decks/${result.data.slug}?created=deck`);
         } else {
           setSubmitError(result.error || "Failed to create deck");
         }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -175,3 +175,12 @@ select:focus {
   font-size: 0.75rem;
   color: var(--terminal-muted);
 }
+
+.terminal-notice {
+  border: 1px solid var(--terminal-border-strong);
+  background: rgba(57, 197, 187, 0.08);
+  color: var(--terminal-soft);
+  padding: 0.9rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.6;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,13 +3,14 @@ import { filterCards, listCards, listTags, searchCards } from "@/lib/cards";
 import { listDecks } from "@/lib/decks";
 
 type Props = {
-  searchParams?: Promise<{ tag?: string; q?: string }>;
+  searchParams?: Promise<{ tag?: string; q?: string; created?: string }>;
 };
 
 export default async function Home({ searchParams }: Props) {
   const resolvedSearchParams = (await searchParams) ?? {};
   const tag = resolvedSearchParams.tag;
   const query = resolvedSearchParams.q ?? "";
+  const created = resolvedSearchParams.created;
   const allCards = await listCards();
   const allDecks = await listDecks();
   const searchedCards = searchCards(query, allCards);
@@ -18,6 +19,10 @@ export default async function Home({ searchParams }: Props) {
   );
   const tags = listTags(allCards);
   const featuredDecks = allDecks.filter((deck) => deck.featured).slice(0, 3);
+  const hasFilters = Boolean(query || tag);
+  const resultLabel = hasFilters
+    ? `검색/필터 결과 ${cards.length}개`
+    : `전체 카드 ${cards.length}개`;
 
   return (
     <div className="min-h-screen text-white">
@@ -44,6 +49,12 @@ export default async function Home({ searchParams }: Props) {
               </div>
             </div>
 
+            {created === "card" && (
+              <div className="terminal-notice mt-5">
+                카드가 저장됐어요. 이제 태그를 고르거나 검색해서 바로 위치를 확인할 수 있어요.
+              </div>
+            )}
+
             <form action="/" className="mt-6 flex flex-col gap-3 sm:flex-row">
               <input
                 type="text"
@@ -58,9 +69,10 @@ export default async function Home({ searchParams }: Props) {
             </form>
 
             <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--terminal-muted)]">
-              <span>{cards.length}개 표시 중</span>
-              {(query || tag) && <span>· 현재 필터 적용됨</span>}
-              {(query || tag) && (
+              <span>{resultLabel}</span>
+              {query && <span>· 검색어: “{query}”</span>}
+              {tag && <span>· 태그: #{tag}</span>}
+              {hasFilters && (
                 <Link href="/" className="text-[var(--terminal-soft)] underline-offset-4 hover:underline">
                   초기화
                 </Link>


### PR DESCRIPTION
## 🎵 변경 사항
- 홈 화면에 검색/필터 결과 상태를 더 명확하게 표시
- 카드 생성 후 홈으로 돌아왔을 때 성공 안내 배너 추가
- 덱 생성 후 상세 화면에서 바로 다음 행동이 보이는 성공 안내 배너 추가
- 공통 notice 스타일을 추가해 작성 완료 피드백을 더 분명하게 정리

## 🎤 동기 / 맥락
화면 구조와 정보 계층을 정리한 다음 단계로, 사용자가 검색 중인지 작성 직후인지 바로 이해할 수 있도록 피드백 흐름을 보강했습니다.

## 🎹 테스트
- [x] `pnpm typecheck`
- [x] `pnpm test`

## ✅ 체크리스트
- [x] 코드가 프로젝트 스타일 가이드를 따름
- [x] self-review 완료
- [x] 파괴적 변경 없음
