### PR TITLE
feat(cards): add YouTube embed support

### DIFF
--- a/__tests__/card-actions.test.ts
+++ b/__tests__/card-actions.test.ts
@@ -59,6 +59,7 @@ describe("card actions", () => {
       type: "song",
       tags: ["classic", "romance"],
       source_url: "https://example.com",
+      youtube_url: "https://www.youtube.com/watch?v=o1jAMSQyVPc",
     });
 
     expect(from).toHaveBeenCalledWith("cards");
@@ -69,6 +70,7 @@ describe("card actions", () => {
       character: "Hatsune Miku",
       tags: ["classic", "romance"],
       source_url: "https://example.com",
+      youtube_url: "https://www.youtube.com/watch?v=o1jAMSQyVPc",
     });
     expect(result).toEqual({
       success: true,

--- a/__tests__/card-detail.test.ts
+++ b/__tests__/card-detail.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getCardBySlug, cards } from "@/lib/cards";
+import { cards, getCardBySlug, getYouTubeEmbedUrl } from "@/lib/cards";
 
 describe("card detail", () => {
   it("returns a card by slug", () => {
@@ -12,5 +12,23 @@ describe("card detail", () => {
   it("returns undefined for unknown slug", () => {
     const card = getCardBySlug("missing-slug");
     expect(card).toBeUndefined();
+  });
+
+  it("parses supported youtube urls into embed urls", () => {
+    expect(getYouTubeEmbedUrl("https://www.youtube.com/watch?v=o1jAMSQyVPc")).toBe(
+      "https://www.youtube.com/embed/o1jAMSQyVPc"
+    );
+    expect(getYouTubeEmbedUrl("https://youtu.be/vnw8zURAxkU")).toBe(
+      "https://www.youtube.com/embed/vnw8zURAxkU"
+    );
+    expect(getYouTubeEmbedUrl("https://www.youtube.com/shorts/o1jAMSQyVPc")).toBe(
+      "https://www.youtube.com/embed/o1jAMSQyVPc"
+    );
+  });
+
+  it("ignores invalid or non-youtube urls", () => {
+    expect(getYouTubeEmbedUrl("https://example.com/video")).toBeUndefined();
+    expect(getYouTubeEmbedUrl("https://www.youtube.com/watch?v=short")).toBeUndefined();
+    expect(getYouTubeEmbedUrl("not-a-url")).toBeUndefined();
   });
 });

--- a/__tests__/card-form.test.ts
+++ b/__tests__/card-form.test.ts
@@ -7,15 +7,23 @@ const base = {
   type: "song",
   tags: "classic, romance",
   sourceUrl: "https://example.com",
+  youtubeUrl: "https://www.youtube.com/watch?v=o1jAMSQyVPc",
 };
 
 describe("card form helpers", () => {
   it("parses tags from comma-separated string", () => {
-    expect(parseTags("classic, romance,2007")).toEqual([
-      "classic",
-      "romance",
-      "2007",
-    ]);
+    expect(parseTags("classic, romance,2007")).toEqual(["classic", "romance", "2007"]);
+  });
+
+  it("builds payload including optional youtube url", () => {
+    expect(buildCardPayload(base)).toMatchObject({
+      title: "Melt",
+      character: "Hatsune Miku",
+      type: "song",
+      tags: ["classic", "romance"],
+      source_url: "https://example.com",
+      youtube_url: "https://www.youtube.com/watch?v=o1jAMSQyVPc",
+    });
   });
 
   it("validates required fields", () => {

--- a/src/app/cards/[slug]/page.tsx
+++ b/src/app/cards/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { getCardBySlugAsync, getCardExternalLinks } from "@/lib/cards";
+import { getCardBySlugAsync, getCardExternalLinks, getYouTubeEmbedUrl } from "@/lib/cards";
 import { listDecks } from "@/lib/decks";
 
 type Props = {
@@ -26,6 +26,7 @@ export default async function CardDetail({ params }: Props) {
   }
 
   const links = getCardExternalLinks(card);
+  const embedUrl = getYouTubeEmbedUrl(card.youtube_url);
   const decks = await listDecks();
   const relatedDecks = decks.filter((deck) => deck.cards.includes(card.slug));
 
@@ -46,9 +47,7 @@ export default async function CardDetail({ params }: Props) {
               </div>
               <h1 className="mt-3 text-3xl font-semibold sm:text-4xl">{card.title}</h1>
               {card.summary && (
-                <p className="mt-3 max-w-2xl text-sm leading-7 text-[var(--terminal-soft)] sm:text-base">
-                  {card.summary}
-                </p>
+                <p className="mt-3 max-w-2xl text-sm leading-7 text-[var(--terminal-soft)] sm:text-base">{card.summary}</p>
               )}
               <div className="mt-4 flex flex-wrap gap-2">
                 {card.tags.map((item) => (
@@ -63,12 +62,12 @@ export default async function CardDetail({ params }: Props) {
                     관련 덱 보기
                   </Link>
                 )}
-                <a
-                  href={links.youtubeSearch}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="terminal-button w-full sm:w-auto"
-                >
+                {embedUrl && (
+                  <a href="#video" className="terminal-button w-full sm:w-auto">
+                    영상 바로 보기
+                  </a>
+                )}
+                <a href={links.youtubeSearch} target="_blank" rel="noreferrer" className="terminal-button w-full sm:w-auto">
                   YouTube 검색
                 </a>
               </div>
@@ -103,6 +102,10 @@ export default async function CardDetail({ params }: Props) {
                   <span className="text-[var(--terminal-muted)]">연결된 덱</span>
                   <span>{relatedDecks.length}</span>
                 </div>
+                <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
+                  <span className="text-[var(--terminal-muted)]">영상</span>
+                  <span>{embedUrl ? "있음" : "없음"}</span>
+                </div>
               </div>
             </aside>
           </div>
@@ -110,6 +113,30 @@ export default async function CardDetail({ params }: Props) {
 
         <section className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
           <article className="terminal-frame p-5 sm:p-6">
+            {embedUrl && (
+              <section id="video" className="mb-8">
+                <div className="mb-3 flex items-center justify-between gap-4">
+                  <h2 className="text-lg font-semibold">영상</h2>
+                  {links.youtube && (
+                    <a href={links.youtube} target="_blank" rel="noreferrer" className="text-sm text-[var(--terminal-soft)]">
+                      원본 열기 ↗
+                    </a>
+                  )}
+                </div>
+                <div className="overflow-hidden border border-[var(--terminal-border)] bg-black">
+                  <div className="relative aspect-video w-full">
+                    <iframe
+                      src={embedUrl}
+                      title={`${card.title} YouTube player`}
+                      className="absolute inset-0 h-full w-full"
+                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                      allowFullScreen
+                    />
+                  </div>
+                </div>
+              </section>
+            )}
+
             <h2 className="text-lg font-semibold">설명</h2>
             {card.description ? (
               <div className="mt-4 space-y-4 text-sm leading-7 text-[var(--terminal-soft)]">
@@ -149,6 +176,11 @@ export default async function CardDetail({ params }: Props) {
                     원문 보기
                   </a>
                 )}
+                {links.youtube && (
+                  <a href={links.youtube} target="_blank" rel="noreferrer" className="terminal-button text-center">
+                    YouTube 원본
+                  </a>
+                )}
                 <a href={links.youtubeSearch} target="_blank" rel="noreferrer" className="terminal-button text-center">
                   YouTube 검색
                 </a>
@@ -173,9 +205,7 @@ export default async function CardDetail({ params }: Props) {
                         <p className="text-sm font-semibold">{deck.name}</p>
                         <span className="text-xs text-[var(--terminal-muted)]">{deck.cards.length} cards</span>
                       </div>
-                      <p className="mt-1 text-sm leading-6 text-[var(--terminal-muted)]">
-                        {deck.shortPitch ?? deck.description}
-                      </p>
+                      <p className="mt-1 text-sm leading-6 text-[var(--terminal-muted)]">{deck.shortPitch ?? deck.description}</p>
                     </Link>
                   ))
                 ) : (

--- a/src/app/cards/new/page.tsx
+++ b/src/app/cards/new/page.tsx
@@ -3,11 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import {
-  buildCardPayload,
-  CardFormInput,
-  validateCardPayload,
-} from "@/lib/card-form";
+import { buildCardPayload, CardFormInput, validateCardPayload } from "@/lib/card-form";
 import { createCard } from "@/lib/actions/cards";
 
 const initialState: CardFormInput = {
@@ -16,6 +12,7 @@ const initialState: CardFormInput = {
   type: "song",
   tags: "",
   sourceUrl: "",
+  youtubeUrl: "",
 };
 
 const typeOptions = [
@@ -86,6 +83,7 @@ export default function CardCreatePage() {
                 <li>• 제목, 캐릭터, 태그는 필수예요.</li>
                 <li>• 태그는 쉼표로 구분해 입력해요.</li>
                 <li>• 출처 링크는 있으면 나중에 탐색이 쉬워져요.</li>
+                <li>• YouTube 링크를 넣으면 카드 상세에서 바로 재생할 수 있어요.</li>
               </ul>
             </aside>
           </div>
@@ -104,9 +102,7 @@ export default function CardCreatePage() {
                     className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
                     placeholder="예: Melt"
                   />
-                  {errors.includes("title") && (
-                    <p className="text-xs text-[var(--terminal-error)]">제목을 입력해줘.</p>
-                  )}
+                  {errors.includes("title") && <p className="text-xs text-[var(--terminal-error)]">제목을 입력해줘.</p>}
                 </div>
 
                 <div className="space-y-2">
@@ -117,9 +113,7 @@ export default function CardCreatePage() {
                     className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
                     placeholder="예: Hatsune Miku"
                   />
-                  {errors.includes("character") && (
-                    <p className="text-xs text-[var(--terminal-error)]">캐릭터를 입력해줘.</p>
-                  )}
+                  {errors.includes("character") && <p className="text-xs text-[var(--terminal-error)]">캐릭터를 입력해줘.</p>}
                 </div>
 
                 <div className="space-y-2">
@@ -135,9 +129,7 @@ export default function CardCreatePage() {
                       </option>
                     ))}
                   </select>
-                  {errors.includes("type") && (
-                    <p className="text-xs text-[var(--terminal-error)]">타입을 입력해줘.</p>
-                  )}
+                  {errors.includes("type") && <p className="text-xs text-[var(--terminal-error)]">타입을 입력해줘.</p>}
                 </div>
               </div>
             </section>
@@ -152,37 +144,44 @@ export default function CardCreatePage() {
                   className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
                   placeholder="예: classic, romance, live"
                 />
-                <p className="text-xs text-[var(--terminal-muted)]">
-                  여러 태그는 쉼표(,)로 구분해 주세요.
-                </p>
-                {errors.includes("tags") && (
-                  <p className="text-xs text-[var(--terminal-error)]">태그를 하나 이상 입력해줘.</p>
-                )}
+                <p className="text-xs text-[var(--terminal-muted)]">여러 태그는 쉼표(,)로 구분해 주세요.</p>
+                {errors.includes("tags") && <p className="text-xs text-[var(--terminal-error)]">태그를 하나 이상 입력해줘.</p>}
               </div>
             </section>
 
             <section>
               <h2 className="text-lg font-semibold">참고 링크</h2>
-              <div className="mt-4 space-y-2">
-                <label className="text-sm text-[var(--terminal-soft)]">출처 링크</label>
-                <input
-                  value={form.sourceUrl}
-                  onChange={onChange("sourceUrl")}
-                  className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
-                  placeholder="https://..."
-                />
-                <p className="text-xs text-[var(--terminal-muted)]">
-                  공식 링크나 참고 아카이브 주소가 있다면 함께 저장할 수 있어요.
-                </p>
+              <div className="mt-4 space-y-4">
+                <div className="space-y-2">
+                  <label className="text-sm text-[var(--terminal-soft)]">출처 링크</label>
+                  <input
+                    value={form.sourceUrl}
+                    onChange={onChange("sourceUrl")}
+                    className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
+                    placeholder="https://..."
+                  />
+                  <p className="text-xs text-[var(--terminal-muted)]">
+                    공식 링크나 참고 아카이브 주소가 있다면 함께 저장할 수 있어요.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm text-[var(--terminal-soft)]">YouTube 링크</label>
+                  <input
+                    value={form.youtubeUrl}
+                    onChange={onChange("youtubeUrl")}
+                    className="w-full border border-[var(--terminal-border)] bg-[var(--terminal-bg)] px-3 py-3 text-sm text-[var(--terminal-fg)]"
+                    placeholder="https://www.youtube.com/watch?v=..."
+                  />
+                  <p className="text-xs text-[var(--terminal-muted)]">
+                    watch, youtu.be, shorts 링크를 지원해요. 저장 후 카드 상세에서 바로 embed 됩니다.
+                  </p>
+                </div>
               </div>
             </section>
 
             <div className="flex flex-col gap-3 border-t border-[var(--terminal-border)] pt-6 sm:flex-row sm:flex-wrap sm:items-center">
-              <button
-                type="submit"
-                className="terminal-button w-full disabled:opacity-50 sm:w-auto"
-                disabled={isSubmitting}
-              >
+              <button type="submit" className="terminal-button w-full disabled:opacity-50 sm:w-auto" disabled={isSubmitting}>
                 {isSubmitting ? "저장 중..." : "카드 저장"}
               </button>
               <Link className="terminal-button w-full sm:w-auto" href="/">
@@ -206,12 +205,11 @@ export default function CardCreatePage() {
               </div>
               <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
                 <span className="text-[var(--terminal-muted)]">태그 수</span>
-                <span>
-                  {form.tags
-                    .split(",")
-                    .map((item) => item.trim())
-                    .filter(Boolean).length}
-                </span>
+                <span>{form.tags.split(",").map((item) => item.trim()).filter(Boolean).length}</span>
+              </div>
+              <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
+                <span className="text-[var(--terminal-muted)]">YouTube 링크</span>
+                <span>{form.youtubeUrl ? "입력됨" : "없음"}</span>
               </div>
             </div>
           </aside>

--- a/src/data/card-details.ts
+++ b/src/data/card-details.ts
@@ -6,6 +6,7 @@ export type CardDetailSeed = {
   era?: string;
   mood?: string[];
   whyItMatters?: string;
+  youtube_url?: string;
 };
 
 export const cardDetails: Record<string, CardDetailSeed> = {
@@ -20,6 +21,7 @@ export const cardDetails: Record<string, CardDetailSeed> = {
     era: "NicoNico golden age",
     mood: ["bright", "romance", "classic"],
     whyItMatters: "Voxie에서 카드로 남길 가치가 분명한 '시대의 기준점' 같은 곡이에요.",
+    youtube_url: "https://www.youtube.com/watch?v=o1jAMSQyVPc",
   },
   "world-is-mine": {
     summary: "미쿠 캐릭터성을 대중적으로 각인시킨 아이코닉 트랙.",
@@ -44,6 +46,7 @@ export const cardDetails: Record<string, CardDetailSeed> = {
     era: "Band sound / emotional classics",
     mood: ["restless", "cathartic", "rock"],
     whyItMatters: "개별 카드만으로도 설명과 감상을 읽을 이유가 생기는 대표 사례예요.",
+    youtube_url: "https://youtu.be/vnw8zURAxkU",
   },
   "ievan-polkka": {
     summary: "밈과 퍼포먼스로 폭발적으로 확산된 초기 바이럴 미쿠 카드.",

--- a/src/lib/actions/cards.ts
+++ b/src/lib/actions/cards.ts
@@ -7,15 +7,12 @@ import { CardPayload } from "@/lib/card-form";
 import { insertMockCard, isMockWriteModeEnabled } from "@/lib/mock-db";
 
 function generateSlug(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
 export async function createCard(payload: CardPayload) {
   try {
-    const slug = generateSlug(payload.title) + '-' + Date.now();
+    const slug = generateSlug(payload.title) + "-" + Date.now();
 
     if (isMockWriteModeEnabled()) {
       insertMockCard({
@@ -25,6 +22,7 @@ export async function createCard(payload: CardPayload) {
         character: payload.character,
         tags: payload.tags,
         source_url: payload.source_url,
+        youtube_url: payload.youtube_url,
       });
 
       revalidatePath("/");
@@ -35,14 +33,14 @@ export async function createCard(payload: CardPayload) {
         data: {
           slug,
           title: payload.title,
-        }
+        },
       };
     }
 
     if (!isSupabaseConfigured() || !supabase) {
       return {
         success: false,
-        error: "Supabase not configured. Card creation is disabled in local mode."
+        error: "Supabase not configured. Card creation is disabled in local mode.",
       };
     }
 
@@ -55,6 +53,7 @@ export async function createCard(payload: CardPayload) {
         character: payload.character,
         tags: payload.tags,
         source_url: payload.source_url,
+        youtube_url: payload.youtube_url,
       } as any)
       .select()
       .single();
@@ -63,7 +62,7 @@ export async function createCard(payload: CardPayload) {
       console.error("Failed to create card:", error);
       return {
         success: false,
-        error: "Failed to create card: " + error.message
+        error: "Failed to create card: " + error.message,
       };
     }
 
@@ -75,13 +74,13 @@ export async function createCard(payload: CardPayload) {
       data: {
         slug: (data as any).slug,
         title: (data as any).title,
-      }
+      },
     };
   } catch (error) {
     console.error("Unexpected error creating card:", error);
     return {
       success: false,
-      error: "An unexpected error occurred"
+      error: "An unexpected error occurred",
     };
   }
 }

--- a/src/lib/card-form.ts
+++ b/src/lib/card-form.ts
@@ -4,6 +4,7 @@ export type CardFormInput = {
   type: string;
   tags: string;
   sourceUrl?: string;
+  youtubeUrl?: string;
 };
 
 export type CardPayload = {
@@ -12,6 +13,7 @@ export type CardPayload = {
   type: string;
   tags: string[];
   source_url?: string;
+  youtube_url?: string;
 };
 
 export const parseTags = (value: string) =>
@@ -26,6 +28,7 @@ export const buildCardPayload = (input: CardFormInput): CardPayload => ({
   type: input.type.trim(),
   tags: parseTags(input.tags),
   source_url: input.sourceUrl?.trim() || undefined,
+  youtube_url: input.youtubeUrl?.trim() || undefined,
 });
 
 export const validateCardPayload = (payload: CardPayload) => {

--- a/src/lib/cards.ts
+++ b/src/lib/cards.ts
@@ -10,6 +10,7 @@ export type Card = {
   character: string;
   tags: string[];
   source_url?: string;
+  youtube_url?: string;
   summary?: string;
   description?: string[];
   producer?: string;
@@ -19,12 +20,17 @@ export type Card = {
   whyItMatters?: string;
 };
 
-export const cards = (seed as Array<Omit<Card, "summary" | "description" | "producer" | "year" | "era" | "mood" | "whyItMatters">>).map(
-  (card) => ({
-    ...card,
-    ...cardDetails[card.slug],
-  })
-);
+export const cards = (
+  seed as Array<
+    Omit<
+      Card,
+      "summary" | "description" | "producer" | "year" | "era" | "mood" | "whyItMatters"
+    >
+  >
+).map((card) => ({
+  ...card,
+  ...cardDetails[card.slug],
+}));
 
 const enrichCard = (card: {
   slug: string;
@@ -33,6 +39,7 @@ const enrichCard = (card: {
   character: string;
   tags: string[];
   source_url?: string;
+  youtube_url?: string;
 }): Card => ({
   ...card,
   ...cardDetails[card.slug],
@@ -45,6 +52,7 @@ const normalizeCard = (card: {
   character: string;
   tags: string[] | null;
   source_url: string | null;
+  youtube_url: string | null;
 }): Card =>
   enrichCard({
     slug: card.slug,
@@ -53,6 +61,7 @@ const normalizeCard = (card: {
     character: card.character,
     tags: card.tags ?? [],
     source_url: card.source_url ?? undefined,
+    youtube_url: card.youtube_url ?? undefined,
   });
 
 export const listTags = (items: Card[] = cards) => {
@@ -89,7 +98,7 @@ export const listCards = async (): Promise<Card[]> => {
 
   const { data, error } = await supabase
     .from("cards")
-    .select("slug, title, type, character, tags, source_url")
+    .select("slug, title, type, character, tags, source_url, youtube_url")
     .order("title", { ascending: true });
 
   if (error || !data) {
@@ -109,7 +118,7 @@ export const getCardBySlugAsync = async (slug: string): Promise<Card | undefined
 
   const { data, error } = await supabase
     .from("cards")
-    .select("slug, title, type, character, tags, source_url")
+    .select("slug, title, type, character, tags, source_url, youtube_url")
     .eq("slug", slug)
     .maybeSingle();
 
@@ -126,7 +135,36 @@ export const getCardExternalLinks = (card: Card) => {
 
   return {
     source: card.source_url,
+    youtube: card.youtube_url,
     youtubeSearch: `https://www.youtube.com/results?search_query=${query}`,
     niconicoSearch: `https://www.nicovideo.jp/search/${query}`,
   };
+};
+
+export const getYouTubeEmbedUrl = (url?: string) => {
+  if (!url) return undefined;
+
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+
+    let videoId: string | null = null;
+
+    if (host === "youtu.be") {
+      videoId = parsed.pathname.slice(1).split("/")[0] || null;
+    } else if (host === "youtube.com" || host === "m.youtube.com") {
+      if (parsed.pathname === "/watch") {
+        videoId = parsed.searchParams.get("v");
+      } else if (parsed.pathname.startsWith("/embed/")) {
+        videoId = parsed.pathname.split("/")[2] || null;
+      } else if (parsed.pathname.startsWith("/shorts/")) {
+        videoId = parsed.pathname.split("/")[2] || null;
+      }
+    }
+
+    if (!videoId || !/^[A-Za-z0-9_-]{11}$/.test(videoId)) return undefined;
+    return `https://www.youtube.com/embed/${videoId}`;
+  } catch {
+    return undefined;
+  }
 };

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -18,6 +18,7 @@ export interface Database {
           character: string
           tags: string[]
           source_url: string | null
+          youtube_url: string | null
           created_at: string
           updated_at: string
         }
@@ -29,6 +30,7 @@ export interface Database {
           character: string
           tags?: string[]
           source_url?: string | null
+          youtube_url?: string | null
           created_at?: string
           updated_at?: string
         }
@@ -40,6 +42,7 @@ export interface Database {
           character?: string
           tags?: string[]
           source_url?: string | null
+          youtube_url?: string | null
           created_at?: string
           updated_at?: string
         }

--- a/supabase/migrations/002_add_youtube_url_to_cards.sql
+++ b/supabase/migrations/002_add_youtube_url_to_cards.sql
@@ -1,0 +1,2 @@
+ALTER TABLE cards
+ADD COLUMN IF NOT EXISTS youtube_url TEXT;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -2,12 +2,12 @@
 -- This file can be run to populate the database with initial data
 
 -- Insert sample cards (matching existing seed.json structure)
-INSERT INTO cards (slug, title, type, character, tags, source_url) VALUES
-  ('melt', 'Melt', 'song', 'Hatsune Miku', ARRAY['classic', 'romance', '2007'], 'https://mikudb.moe/classic-miku-songs/'),
-  ('world-is-mine', 'World is Mine', 'song', 'Hatsune Miku', ARRAY['classic', 'iconic'], 'https://mikudb.moe/classic-miku-songs/'),
-  ('rolling-girl', 'Rolling Girl', 'song', 'Hatsune Miku', ARRAY['emotional', 'wowaka'], NULL),
-  ('ievan-polkka', 'Ievan Polkka', 'song', 'Hatsune Miku', ARRAY['meme', 'classic'], NULL),
-  ('reverse-rainbow', 'Reverse Rainbow', 'song', 'Rin & Len', ARRAY['duet', 'emotional'], NULL)
+INSERT INTO cards (slug, title, type, character, tags, source_url, youtube_url) VALUES
+  ('melt', 'Melt', 'song', 'Hatsune Miku', ARRAY['classic', 'romance', '2007'], 'https://mikudb.moe/classic-miku-songs/', 'https://www.youtube.com/watch?v=o1jAMSQyVPc'),
+  ('world-is-mine', 'World is Mine', 'song', 'Hatsune Miku', ARRAY['classic', 'iconic'], 'https://mikudb.moe/classic-miku-songs/', NULL),
+  ('rolling-girl', 'Rolling Girl', 'song', 'Hatsune Miku', ARRAY['emotional', 'wowaka'], NULL, 'https://youtu.be/vnw8zURAxkU'),
+  ('ievan-polkka', 'Ievan Polkka', 'song', 'Hatsune Miku', ARRAY['meme', 'classic'], NULL, NULL),
+  ('reverse-rainbow', 'Reverse Rainbow', 'song', 'Rin & Len', ARRAY['duet', 'emotional'], NULL, NULL)
 ON CONFLICT (slug) DO NOTHING;
 
 -- Insert sample decks


### PR DESCRIPTION
## 🎵 변경 사항
- 카드에 선택적 `youtube_url` 저장 지원 추가
- 카드 생성 폼에 YouTube 링크 입력 필드 추가
- 카드 상세에서 지원되는 YouTube 링크를 embed로 렌더링
- invalid/non-YouTube 링크는 안전하게 무시
- Supabase 타입/시드/마이그레이션과 관련 테스트 업데이트

## 🎤 관련 이슈
- Closes #34

## 🎹 테스트
- [x] `pnpm typecheck`
- [x] `pnpm test`
