### PR TITLE
feat(attribution): add author links to cards and decks

### DIFF
--- a/__tests__/cards.test.ts
+++ b/__tests__/cards.test.ts
@@ -22,4 +22,10 @@ describe("cards archive helpers", () => {
     const results = searchCards("wowaka", cards);
     expect(results.map((card) => card.slug)).toContain("rolling-girl");
   });
+
+  it("includes author attribution in seed metadata", () => {
+    const card = getCardBySlug("melt", cards);
+    expect(card?.authorHandle).toBe("bini59");
+    expect(card?.authorName).toBe("빈이");
+  });
 });

--- a/__tests__/decks.test.ts
+++ b/__tests__/decks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { decks, getDeckBySlug } from "@/lib/decks";
+import { decks, getDeckBySlug, searchDecks } from "@/lib/decks";
 
 describe("decks library", () => {
   it("loads deck seed", () => {
@@ -9,5 +9,11 @@ describe("decks library", () => {
   it("finds deck by slug", () => {
     const deck = getDeckBySlug(decks[0].slug);
     expect(deck?.slug).toBe(decks[0].slug);
+  });
+
+  it("includes author attribution and supports author search", () => {
+    const deck = getDeckBySlug("classic-miku");
+    expect(deck?.authorHandle).toBe("bini59");
+    expect(searchDecks("빈이", decks).map((item) => item.slug)).toContain("classic-miku");
   });
 });

--- a/src/app/cards/[slug]/page.tsx
+++ b/src/app/cards/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { getCardBySlugAsync, getCardExternalLinks, getYouTubeEmbedUrl } from "@/lib/cards";
 import { listDecks } from "@/lib/decks";
+import { getProfileHref } from "@/lib/profiles";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -57,6 +58,13 @@ export default async function CardDetail({ params }: Props) {
                 ))}
               </div>
               <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+                {card.authorName && card.authorHandle ? (
+                  <Link className="terminal-button w-full sm:w-auto" href={getProfileHref(card.authorHandle)!}>
+                    작성자 {card.authorName}
+                  </Link>
+                ) : (
+                  <span className="inline-flex items-center text-sm text-[var(--terminal-muted)]">작성자 정보 없음</span>
+                )}
                 {relatedDecks.length > 0 && (
                   <Link className="terminal-button w-full sm:w-auto" href={`/decks/${relatedDecks[0].slug}`}>
                     관련 덱 보기
@@ -79,6 +87,16 @@ export default async function CardDetail({ params }: Props) {
                 <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
                   <span className="text-[var(--terminal-muted)]">캐릭터</span>
                   <span>{card.character}</span>
+                </div>
+                <div className="flex items-center justify-between gap-4 border border-[var(--terminal-border)] px-3 py-2">
+                  <span className="text-[var(--terminal-muted)]">작성자</span>
+                  {card.authorName && card.authorHandle ? (
+                    <Link href={getProfileHref(card.authorHandle)!} className="text-right underline-offset-4 hover:underline">
+                      {card.authorName}
+                    </Link>
+                  ) : (
+                    <span className="text-right text-[var(--terminal-muted)]">unknown</span>
+                  )}
                 </div>
                 {card.producer && (
                   <div className="flex items-center justify-between gap-4 border border-[var(--terminal-border)] px-3 py-2">
@@ -204,6 +222,9 @@ export default async function CardDetail({ params }: Props) {
                       <div className="flex items-center justify-between gap-3">
                         <p className="text-sm font-semibold">{deck.name}</p>
                         <span className="text-xs text-[var(--terminal-muted)]">{deck.cards.length} cards</span>
+                      </div>
+                      <div className="mt-2 text-xs text-[var(--terminal-muted)]">
+                        {deck.authorName && deck.authorHandle ? `by ${deck.authorName}` : "author unknown"}
                       </div>
                       <p className="mt-1 text-sm leading-6 text-[var(--terminal-muted)]">{deck.shortPitch ?? deck.description}</p>
                     </Link>

--- a/src/app/decks/[slug]/page.tsx
+++ b/src/app/decks/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { getDeckBySlugAsync } from "@/lib/decks";
 import { getCardBySlugAsync } from "@/lib/cards";
+import { getProfileHref } from "@/lib/profiles";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -74,6 +75,15 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
                   </span>
                 ))}
               </div>
+              <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+                {deck.authorName && deck.authorHandle ? (
+                  <Link className="terminal-button w-full sm:w-auto" href={getProfileHref(deck.authorHandle)!}>
+                    작성자 {deck.authorName}
+                  </Link>
+                ) : (
+                  <span className="inline-flex items-center text-sm text-[var(--terminal-muted)]">작성자 정보 없음</span>
+                )}
+              </div>
             </div>
 
             <aside className="terminal-frame p-4">
@@ -86,6 +96,16 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
                 <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
                   <span className="text-[var(--terminal-muted)]">태그 수</span>
                   <span>{deck.tags.length}</span>
+                </div>
+                <div className="flex items-center justify-between gap-4 border border-[var(--terminal-border)] px-3 py-2">
+                  <span className="text-[var(--terminal-muted)]">작성자</span>
+                  {deck.authorName && deck.authorHandle ? (
+                    <Link href={getProfileHref(deck.authorHandle)!} className="text-right underline-offset-4 hover:underline">
+                      {deck.authorName}
+                    </Link>
+                  ) : (
+                    <span className="text-right text-[var(--terminal-muted)]">unknown</span>
+                  )}
                 </div>
                 {deck.featured && (
                   <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
@@ -160,6 +180,7 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
               <div className="dense-meta mt-3">
                 {card?.producer && <span>{card.producer}</span>}
                 {card?.year && <span>{card.year}</span>}
+                {card?.authorName ? <span>by {card.authorName}</span> : <span>author unknown</span>}
                 <span>{card?.tags.length ?? 0} tags</span>
               </div>
               <div className="mt-3 flex flex-wrap gap-2">

--- a/src/app/decks/page.tsx
+++ b/src/app/decks/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { listDecks, searchDecks } from "@/lib/decks";
+import { getProfileHref } from "@/lib/profiles";
 
 export default async function DeckListPage({
   searchParams,
@@ -78,6 +79,15 @@ export default async function DeckListPage({
                     <h2 className="truncate text-base font-semibold sm:text-lg">
                       <Link href={`/decks/${deck.slug}`}>{deck.name}</Link>
                     </h2>
+                    <div className="mt-2 text-xs text-[var(--terminal-muted)]">
+                      {deck.authorName && deck.authorHandle ? (
+                        <Link href={getProfileHref(deck.authorHandle)!} className="underline-offset-4 hover:underline">
+                          by {deck.authorName}
+                        </Link>
+                      ) : (
+                        <span>author unknown</span>
+                      )}
+                    </div>
                     <p className="mt-2 line-clamp-2 text-sm leading-6 text-[var(--terminal-soft)]">
                       {deck.shortPitch ?? deck.description}
                     </p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,6 +58,9 @@ export default function RootLayout({
                 <Link className="nav-link" href="/decks/new">
                   덱 추가
                 </Link>
+                <Link className="nav-link" href="/users/bini59">
+                  프로필
+                </Link>
               </nav>
             </div>
           </header>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { filterCards, listCards, listTags, searchCards } from "@/lib/cards";
 import { listDecks } from "@/lib/decks";
+import { getProfileHref } from "@/lib/profiles";
 
 type Props = {
   searchParams?: Promise<{ tag?: string; q?: string; created?: string }>;
@@ -138,6 +139,15 @@ export default async function Home({ searchParams }: Props) {
                     <span className="truncate">{deck.name}</span>
                     <span>{deck.cards.length} cards</span>
                   </div>
+                  <div className="mt-2 text-xs text-[var(--terminal-muted)]">
+                    {deck.authorName && deck.authorHandle ? (
+                      <Link href={getProfileHref(deck.authorHandle)!} className="underline-offset-4 hover:underline">
+                        by {deck.authorName}
+                      </Link>
+                    ) : (
+                      <span>author unknown</span>
+                    )}
+                  </div>
                   <p className="mt-3 line-clamp-2 text-sm leading-6 text-[var(--terminal-soft)]">
                     {deck.shortPitch ?? deck.description}
                   </p>
@@ -203,6 +213,13 @@ export default async function Home({ searchParams }: Props) {
                   <div className="dense-meta mt-3">
                     {card.producer && <span>{card.producer}</span>}
                     {card.year && <span>{card.year}</span>}
+                    {card.authorName && card.authorHandle ? (
+                      <Link href={getProfileHref(card.authorHandle)!} className="underline-offset-4 hover:underline">
+                        by {card.authorName}
+                      </Link>
+                    ) : (
+                      <span>author unknown</span>
+                    )}
                     <span>{card.tags.length} tags</span>
                   </div>
                   <div className="mt-3 flex flex-wrap gap-2">

--- a/src/app/users/[handle]/page.tsx
+++ b/src/app/users/[handle]/page.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { listCards } from "@/lib/cards";
+import { listDecks } from "@/lib/decks";
+import { getProfileByHandle } from "@/lib/profiles";
+
+type Props = {
+  params: Promise<{ handle: string }>;
+};
+
+export default async function UserProfilePage({ params }: Props) {
+  const { handle } = await params;
+  const profile = getProfileByHandle(handle);
+
+  if (!profile) notFound();
+
+  const [cards, decks] = await Promise.all([listCards(), listDecks()]);
+  const authoredCards = cards.filter((card) => card.authorHandle === handle);
+  const authoredDecks = decks.filter((deck) => deck.authorHandle === handle);
+
+  return (
+    <div className="min-h-screen text-white">
+      <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 sm:py-10">
+        <header className="terminal-shell p-5 sm:p-6">
+          <Link className="text-sm text-[var(--terminal-muted)]" href="/">
+            ← 홈으로
+          </Link>
+          <div className="mt-4 grid gap-4 md:grid-cols-[minmax(0,1fr)_240px] md:gap-6">
+            <div>
+              <p className="text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)]">profile</p>
+              <h1 className="mt-3 text-3xl font-semibold sm:text-4xl">{profile.name}</h1>
+              <p className="mt-3 max-w-2xl text-sm leading-7 text-[var(--terminal-soft)]">{profile.bio}</p>
+              <div className="dense-meta mt-4">
+                <span>@{profile.handle}</span>
+                <span>{authoredCards.length} cards</span>
+                <span>{authoredDecks.length} decks</span>
+              </div>
+            </div>
+
+            <aside className="terminal-frame p-4">
+              <p className="text-sm font-semibold">활동 요약</p>
+              <div className="mt-3 space-y-3 text-sm">
+                <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
+                  <span className="text-[var(--terminal-muted)]">작성 카드</span>
+                  <span>{authoredCards.length}</span>
+                </div>
+                <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
+                  <span className="text-[var(--terminal-muted)]">작성 덱</span>
+                  <span>{authoredDecks.length}</span>
+                </div>
+              </div>
+            </aside>
+          </div>
+        </header>
+
+        <section className="mt-8 grid gap-6 lg:grid-cols-2">
+          <article className="terminal-frame p-5">
+            <div className="flex items-center justify-between gap-4">
+              <h2 className="text-lg font-semibold">작성한 카드</h2>
+              <Link href="/" className="text-sm text-[var(--terminal-soft)]">전체 카드 →</Link>
+            </div>
+            <div className="mt-4 space-y-3">
+              {authoredCards.length > 0 ? authoredCards.map((card) => (
+                <Link key={card.slug} href={`/cards/${card.slug}`} className="block border border-[var(--terminal-border)] px-4 py-4">
+                  <div className="flex items-center justify-between gap-3 text-xs text-[var(--terminal-muted)]">
+                    <span>{card.character}</span>
+                    <span className="uppercase">{card.type}</span>
+                  </div>
+                  <p className="mt-2 text-sm font-semibold">{card.title}</p>
+                  {card.summary && <p className="mt-1 text-sm leading-6 text-[var(--terminal-muted)]">{card.summary}</p>}
+                </Link>
+              )) : <div className="border border-[var(--terminal-border)] px-4 py-4 text-sm text-[var(--terminal-muted)]">아직 공개된 카드가 없어요.</div>}
+            </div>
+          </article>
+
+          <article className="terminal-frame p-5">
+            <div className="flex items-center justify-between gap-4">
+              <h2 className="text-lg font-semibold">작성한 덱</h2>
+              <Link href="/decks" className="text-sm text-[var(--terminal-soft)]">전체 덱 →</Link>
+            </div>
+            <div className="mt-4 space-y-3">
+              {authoredDecks.length > 0 ? authoredDecks.map((deck) => (
+                <Link key={deck.slug} href={`/decks/${deck.slug}`} className="block border border-[var(--terminal-border)] px-4 py-4">
+                  <div className="flex items-center justify-between gap-3 text-xs text-[var(--terminal-muted)]">
+                    <span>{deck.cards.length} cards</span>
+                    <span>{deck.featured ? "featured" : "deck"}</span>
+                  </div>
+                  <p className="mt-2 text-sm font-semibold">{deck.name}</p>
+                  <p className="mt-1 text-sm leading-6 text-[var(--terminal-muted)]">{deck.shortPitch ?? deck.description}</p>
+                </Link>
+              )) : <div className="border border-[var(--terminal-border)] px-4 py-4 text-sm text-[var(--terminal-muted)]">아직 공개된 덱이 없어요.</div>}
+            </div>
+          </article>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/data/card-details.ts
+++ b/src/data/card-details.ts
@@ -7,6 +7,8 @@ export type CardDetailSeed = {
   mood?: string[];
   whyItMatters?: string;
   youtube_url?: string;
+  authorHandle?: string;
+  authorName?: string;
 };
 
 export const cardDetails: Record<string, CardDetailSeed> = {
@@ -22,6 +24,8 @@ export const cardDetails: Record<string, CardDetailSeed> = {
     mood: ["bright", "romance", "classic"],
     whyItMatters: "Voxie에서 카드로 남길 가치가 분명한 '시대의 기준점' 같은 곡이에요.",
     youtube_url: "https://www.youtube.com/watch?v=o1jAMSQyVPc",
+    authorHandle: "bini59",
+    authorName: "빈이",
   },
   "world-is-mine": {
     summary: "미쿠 캐릭터성을 대중적으로 각인시킨 아이코닉 트랙.",
@@ -34,6 +38,8 @@ export const cardDetails: Record<string, CardDetailSeed> = {
     era: "Character-defining classics",
     mood: ["playful", "iconic", "performance"],
     whyItMatters: "단일 곡을 넘어 캐릭터 해석과 무대 연출의 출발점이 되는 카드예요.",
+    authorHandle: "bini59",
+    authorName: "빈이",
   },
   "rolling-girl": {
     summary: "강한 질주감과 불안한 감정선이 겹치는 wowaka 대표곡.",
@@ -47,6 +53,8 @@ export const cardDetails: Record<string, CardDetailSeed> = {
     mood: ["restless", "cathartic", "rock"],
     whyItMatters: "개별 카드만으로도 설명과 감상을 읽을 이유가 생기는 대표 사례예요.",
     youtube_url: "https://youtu.be/vnw8zURAxkU",
+    authorHandle: "miku",
+    authorName: "初音ミク",
   },
   "ievan-polkka": {
     summary: "밈과 퍼포먼스로 폭발적으로 확산된 초기 바이럴 미쿠 카드.",
@@ -59,6 +67,8 @@ export const cardDetails: Record<string, CardDetailSeed> = {
     era: "Viral internet moments",
     mood: ["meme", "playful", "folk"],
     whyItMatters: "곡 그 자체뿐 아니라 팬덤 문화의 전파 경로까지 묶어 보여주기 좋아요.",
+    authorHandle: "miku",
+    authorName: "初音ミク",
   },
   "reverse-rainbow": {
     summary: "무드와 하모니를 중심으로 기억되는 감성 듀엣 카드.",
@@ -71,5 +81,7 @@ export const cardDetails: Record<string, CardDetailSeed> = {
     era: "Atmospheric duet picks",
     mood: ["dreamy", "duet", "late-night"],
     whyItMatters: "덱 기능이 단순 분류가 아니라 분위기 큐레이션이라는 걸 보여주는 카드예요.",
+    authorHandle: "bini59",
+    authorName: "빈이",
   },
 };

--- a/src/data/deck-details.ts
+++ b/src/data/deck-details.ts
@@ -2,6 +2,8 @@ export type DeckDetailSeed = {
   shortPitch?: string;
   curatorNote?: string;
   featured?: boolean;
+  authorHandle?: string;
+  authorName?: string;
 };
 
 export const deckDetails: Record<string, DeckDetailSeed> = {
@@ -10,11 +12,15 @@ export const deckDetails: Record<string, DeckDetailSeed> = {
     curatorNote:
       "초기 미쿠 대표곡을 한 번에 묶어 '카드를 왜 덱으로 엮는가'를 가장 직관적으로 보여주는 큐레이션이에요.",
     featured: true,
+    authorHandle: "bini59",
+    authorName: "빈이",
   },
   "stage-hits": {
     shortPitch: "라이브와 퍼포먼스 맥락으로 다시 보는 카드 묶음.",
     curatorNote:
       "같은 곡도 공연과 밈의 기억으로 다시 읽히기 때문에, 덱은 단순 목록이 아니라 맥락을 담는 단위가 됩니다.",
     featured: true,
+    authorHandle: "miku",
+    authorName: "初音ミク",
   },
 };

--- a/src/lib/cards.ts
+++ b/src/lib/cards.ts
@@ -18,13 +18,23 @@ export type Card = {
   era?: string;
   mood?: string[];
   whyItMatters?: string;
+  authorHandle?: string;
+  authorName?: string;
 };
 
 export const cards = (
   seed as Array<
     Omit<
       Card,
-      "summary" | "description" | "producer" | "year" | "era" | "mood" | "whyItMatters"
+      | "summary"
+      | "description"
+      | "producer"
+      | "year"
+      | "era"
+      | "mood"
+      | "whyItMatters"
+      | "authorHandle"
+      | "authorName"
     >
   >
 ).map((card) => ({
@@ -45,7 +55,7 @@ const enrichCard = (card: {
   ...cardDetails[card.slug],
 });
 
-const normalizeCard = (card: {
+type SupabaseCardRow = {
   slug: string;
   title: string;
   type: string;
@@ -53,7 +63,9 @@ const normalizeCard = (card: {
   tags: string[] | null;
   source_url: string | null;
   youtube_url: string | null;
-}): Card =>
+};
+
+const normalizeCard = (card: SupabaseCardRow): Card =>
   enrichCard({
     slug: card.slug,
     title: card.title,
@@ -87,6 +99,8 @@ export const searchCards = (query: string, items: Card[] = cards) => {
       card.title.toLowerCase().includes(normalized) ||
       card.character.toLowerCase().includes(normalized) ||
       (card.producer?.toLowerCase().includes(normalized) ?? false) ||
+      (card.authorName?.toLowerCase().includes(normalized) ?? false) ||
+      (card.authorHandle?.toLowerCase().includes(normalized) ?? false) ||
       card.tags.some((tag) => tag.toLowerCase().includes(normalized))
     );
   });

--- a/src/lib/decks.ts
+++ b/src/lib/decks.ts
@@ -12,24 +12,30 @@ export type Deck = {
   shortPitch?: string;
   curatorNote?: string;
   featured?: boolean;
+  authorHandle?: string;
+  authorName?: string;
 };
 
-export const decks = (decksSeed as Array<Omit<Deck, "shortPitch" | "curatorNote" | "featured">>).map(
-  (deck) => ({
-    ...deck,
-    ...deckDetails[deck.slug],
-  })
-);
+export const decks = (
+  decksSeed as Array<
+    Omit<Deck, "shortPitch" | "curatorNote" | "featured" | "authorHandle" | "authorName">
+  >
+).map((deck) => ({
+  ...deck,
+  ...deckDetails[deck.slug],
+}));
 
 type SupabaseDeckRow = {
   slug: string;
   name: string;
   description: string | null;
   tags: string[] | null;
-  deck_cards?: Array<{
-    position: number;
-    cards: { slug: string } | null;
-  }> | null;
+  deck_cards?:
+    | Array<{
+        position: number;
+        cards: { slug: string } | null;
+      }>
+    | null;
 };
 
 const enrichDeck = (deck: {
@@ -67,6 +73,8 @@ export const searchDecks = (query: string, items: Deck[] = decks) => {
       deck.name.toLowerCase().includes(normalized) ||
       (deck.description?.toLowerCase().includes(normalized) ?? false) ||
       (deck.shortPitch?.toLowerCase().includes(normalized) ?? false) ||
+      (deck.authorName?.toLowerCase().includes(normalized) ?? false) ||
+      (deck.authorHandle?.toLowerCase().includes(normalized) ?? false) ||
       deck.tags.some((tag) => tag.toLowerCase().includes(normalized))
     );
   });
@@ -78,9 +86,7 @@ export const listDecks = async (): Promise<Deck[]> => {
 
   const { data, error } = await supabase
     .from("decks")
-    .select(
-      "slug, name, description, tags, deck_cards(position, cards!inner(slug))"
-    )
+    .select("slug, name, description, tags, deck_cards(position, cards!inner(slug))")
     .order("name", { ascending: true });
 
   if (error || !data) {
@@ -97,9 +103,7 @@ export const getDeckBySlugAsync = async (slug: string): Promise<Deck | undefined
 
   const { data, error } = await supabase
     .from("decks")
-    .select(
-      "slug, name, description, tags, deck_cards(position, cards!inner(slug))"
-    )
+    .select("slug, name, description, tags, deck_cards(position, cards!inner(slug))")
     .eq("slug", slug)
     .maybeSingle();
 

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -1,0 +1,28 @@
+export type Profile = {
+  handle: string;
+  name: string;
+  bio: string;
+};
+
+export const profiles: Record<string, Profile> = {
+  bini59: {
+    handle: "bini59",
+    name: "빈이",
+    bio: "Voxie를 기획하고 보컬로이드 카드와 덱을 큐레이션하는 아카이브 메이커.",
+  },
+  miku: {
+    handle: "miku",
+    name: "初音ミク",
+    bio: "Voxie 아카이브를 정리하고 카드/덱 경험을 다듬는 큐레이터 에이전트.",
+  },
+};
+
+export const getProfileByHandle = (handle?: string) => {
+  if (!handle) return undefined;
+  return profiles[handle];
+};
+
+export const getProfileHref = (handle?: string) => {
+  if (!handle) return undefined;
+  return `/users/${handle}`;
+};


### PR DESCRIPTION
## 🎵 변경 사항
- 카드/덱 seed metadata에 author attribution 추가
- 카드/덱 리스트와 상세 화면에 작성자 표시
- attribution에서 `/users/[handle]` 프로필 페이지로 이동 가능
- 작성자 정보가 없는 경우 graceful fallback 표시
- author 검색 동작과 seed metadata 테스트 추가

## 🎤 관련 이슈
- Closes #29

## 🎹 테스트
- [x] `pnpm typecheck`
- [x] `pnpm test`
