### PR TITLE
feat(deck): add public sharing flow

### DIFF
--- a/__tests__/deck-share.test.ts
+++ b/__tests__/deck-share.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from "vitest";
+import { decks, getDeckBySlug } from "@/lib/decks";
+import { getDeckShareDescription, getDeckShareUrl } from "@/lib/deck-share";
+
+describe("deck share helpers", () => {
+  it("builds a stable public deck url from slug", () => {
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://voxie.test");
+    expect(getDeckShareUrl("classic-miku")).toBe("https://voxie.test/decks/classic-miku");
+    vi.unstubAllEnvs();
+  });
+
+  it("creates a readable share description from deck content", () => {
+    const deck = getDeckBySlug("classic-miku", decks);
+    expect(deck).toBeTruthy();
+    expect(getDeckShareDescription(deck!)).toContain("Voxie");
+  });
+});

--- a/src/app/decks/[slug]/ShareDeckActions.tsx
+++ b/src/app/decks/[slug]/ShareDeckActions.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = {
+  title: string;
+  url: string;
+};
+
+export default function ShareDeckActions({ title, url }: Props) {
+  const [status, setStatus] = useState<"idle" | "copied" | "shared" | "error">("idle");
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setStatus("copied");
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  const shareLink = async () => {
+    if (typeof navigator === "undefined") return;
+
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title,
+          text: `${title} 덱을 공유해요`,
+          url,
+        });
+        setStatus("shared");
+        return;
+      } catch {
+        // fall through to copy flow if native share is cancelled/unavailable
+      }
+    }
+
+    await copyLink();
+  };
+
+  return (
+    <div className="terminal-frame p-4">
+      <p className="text-sm font-semibold">공유</p>
+      <p className="mt-2 break-all text-xs leading-6 text-[var(--terminal-muted)]">{url}</p>
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+        <button type="button" className="terminal-button w-full sm:w-auto" onClick={shareLink}>
+          공유하기
+        </button>
+        <button type="button" className="terminal-button w-full sm:w-auto" onClick={copyLink}>
+          링크 복사
+        </button>
+      </div>
+      {status === "copied" && <p className="mt-3 text-xs text-[var(--terminal-soft)]">링크를 복사했어요.</p>}
+      {status === "shared" && <p className="mt-3 text-xs text-[var(--terminal-soft)]">공유 창을 열었어요.</p>}
+      {status === "error" && <p className="mt-3 text-xs text-[var(--terminal-error)]">링크를 복사하지 못했어요.</p>}
+    </div>
+  );
+}

--- a/src/app/decks/[slug]/page.tsx
+++ b/src/app/decks/[slug]/page.tsx
@@ -1,12 +1,48 @@
+import type { Metadata } from "next";
 import Link from "next/link";
-import { getDeckBySlugAsync } from "@/lib/decks";
+import ShareDeckActions from "./ShareDeckActions";
 import { getCardBySlugAsync, type Card } from "@/lib/cards";
+import { getDeckShareDescription, getDeckShareUrl } from "@/lib/deck-share";
+import { getDeckBySlugAsync } from "@/lib/decks";
 import { getProfileHref } from "@/lib/profiles";
 
 type Props = {
   params: Promise<{ slug: string }>;
   searchParams?: Promise<{ created?: string }>;
 };
+
+export async function generateMetadata({ params }: Pick<Props, "params">): Promise<Metadata> {
+  const { slug } = await params;
+  const deck = await getDeckBySlugAsync(slug);
+
+  if (!deck) {
+    return {
+      title: "덱을 찾을 수 없어요 | Voxie",
+      description: "요청한 Voxie 덱을 찾을 수 없어요.",
+    };
+  }
+
+  const title = `${deck.name} | Voxie`;
+  const description = getDeckShareDescription(deck);
+  const url = getDeckShareUrl(deck.slug);
+
+  return {
+    title,
+    description,
+    alternates: { canonical: `/decks/${deck.slug}` },
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "article",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
 
 export default async function DeckDetailPage({ params, searchParams }: Props) {
   const { slug } = await params;
@@ -29,6 +65,7 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
     );
   }
 
+  const shareUrl = getDeckShareUrl(deck.slug);
   const cards = (await Promise.all(deck.cards.map((cardSlug) => getCardBySlugAsync(cardSlug)))).filter(
     (card): card is Card => Boolean(card),
   );
@@ -72,7 +109,9 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
                 <div className="mt-5 border border-[var(--terminal-border)] bg-[rgba(57,197,187,0.04)] px-4 py-4 sm:px-5">
                   <p className="text-xs uppercase tracking-[0.16em] text-[var(--terminal-muted)]">deck intro</p>
                   <h2 className="mt-2 text-xl font-semibold">{deck.introTitle ?? "이 덱을 읽는 방법"}</h2>
-                  {(deck.intro ?? deck.introBody) && <p className="mt-3 text-sm leading-7 text-[var(--terminal-soft)]">{deck.intro ?? deck.introBody}</p>}
+                  {(deck.intro ?? deck.introBody) && (
+                    <p className="mt-3 text-sm leading-7 text-[var(--terminal-soft)]">{deck.intro ?? deck.introBody}</p>
+                  )}
                 </div>
               )}
               <div className="mt-4 flex flex-wrap gap-2">
@@ -95,6 +134,9 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
                     흐름으로 읽기
                   </a>
                 )}
+                <a className="terminal-button w-full sm:w-auto" href={shareUrl}>
+                  공개 링크 열기
+                </a>
               </div>
             </div>
 
@@ -149,6 +191,38 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
             )}
           </article>
 
+          <ShareDeckActions title={deck.name} url={shareUrl} />
+        </section>
+
+        <section className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <article className="terminal-frame p-5 sm:p-6">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-semibold">이 덱을 공유하는 방법</h2>
+                <p className="mt-1 text-sm text-[var(--terminal-muted)]">
+                  공개 URL 하나로 바로 열리고, 설명과 카드 흐름이 함께 보여서 외부에서 들어와도 맥락을 바로 이해할 수 있어요.
+                </p>
+              </div>
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              <div className="border border-[var(--terminal-border)] px-4 py-4">
+                <p className="text-xs text-[var(--terminal-muted)]">01</p>
+                <p className="mt-2 text-sm font-semibold">안정적인 공개 URL</p>
+                <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">덱 slug 기반 주소라서 다시 공유해도 링크가 흔들리지 않아요.</p>
+              </div>
+              <div className="border border-[var(--terminal-border)] px-4 py-4">
+                <p className="text-xs text-[var(--terminal-muted)]">02</p>
+                <p className="mt-2 text-sm font-semibold">복사/공유 CTA</p>
+                <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">복사 버튼과 네이티브 공유를 같이 제공해서 모바일/데스크탑 둘 다 대응해요.</p>
+              </div>
+              <div className="border border-[var(--terminal-border)] px-4 py-4">
+                <p className="text-xs text-[var(--terminal-muted)]">03</p>
+                <p className="mt-2 text-sm font-semibold">직접 열어도 이해되는 구조</p>
+                <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">인트로, 읽는 가이드, story flow가 바로 보여서 링크 랜딩 품질이 좋아져요.</p>
+              </div>
+            </div>
+          </article>
+
           <aside className="terminal-frame p-5">
             <div className="flex items-center justify-between gap-4">
               <h2 className="text-lg font-semibold">story map</h2>
@@ -162,10 +236,14 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
                 return (
                   <div key={card.slug} className="border border-[var(--terminal-border)] px-4 py-4">
                     <div className="flex items-center justify-between gap-3">
-                      <p className="text-sm font-semibold text-[var(--terminal-fg)]">{String(index + 1).padStart(2, "0")}. {card.title}</p>
+                      <p className="text-sm font-semibold text-[var(--terminal-fg)]">
+                        {String(index + 1).padStart(2, "0")}. {card.title}
+                      </p>
                       <span className="text-xs uppercase text-[var(--terminal-muted)]">{card.type}</span>
                     </div>
-                    {note?.lead && <p className="mt-2 text-xs uppercase tracking-[0.12em] text-[var(--terminal-muted)]">{note.lead}</p>}
+                    {note?.lead && (
+                      <p className="mt-2 text-xs uppercase tracking-[0.12em] text-[var(--terminal-muted)]">{note.lead}</p>
+                    )}
                     <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">{note?.note ?? card.summary}</p>
                   </div>
                 );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import localFont from "next/font/local";
+import { getSiteUrl } from "@/lib/deck-share";
 import "./globals.css";
 
 const galmuri = localFont({
@@ -21,6 +22,7 @@ const galmuri = localFont({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(getSiteUrl()),
   title: "Voxie",
   description: "Vocaloid community card archive",
 };

--- a/src/lib/deck-share.ts
+++ b/src/lib/deck-share.ts
@@ -1,0 +1,16 @@
+import type { Deck } from "@/lib/decks";
+
+const DEFAULT_SITE_URL = "https://voxie.bini59.dev";
+
+export const getSiteUrl = () => {
+  const raw = process.env.NEXT_PUBLIC_SITE_URL || process.env.SITE_URL || DEFAULT_SITE_URL;
+  return raw.replace(/\/$/, "");
+};
+
+export const getDeckShareUrl = (slug: string) => `${getSiteUrl()}/decks/${slug}`;
+
+export const getDeckShareDescription = (deck: Deck) => {
+  const parts = [deck.shortPitch, deck.description, deck.intro, deck.readingGuide].filter(Boolean);
+  const text = parts[0] ?? "보컬로이드 카드를 덱 단위로 큐레이션해 공유하는 Voxie deck";
+  return text.length > 160 ? `${text.slice(0, 157)}...` : text;
+};


### PR DESCRIPTION
## 🎵 변경 사항
- deck detail 페이지에 공유 패널 추가
- 공개 deck URL helper 및 copy/share CTA 추가
- deck page metadata/canonical/open graph/twitter 기본값 추가
- 직접 열어도 공유 맥락이 보이도록 공유 안내 섹션 추가
- share helper 테스트 추가

## 🎤 관련 이슈
- Closes #33

## 🎹 테스트
- [x] `pnpm typecheck`
- [x] `pnpm test`
