### PR TITLE
feat(card): add rich media metadata for video cards

### DIFF
--- a/__tests__/card-detail.test.ts
+++ b/__tests__/card-detail.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { cards, getCardBySlug, getYouTubeEmbedUrl } from "@/lib/cards";
+import { cards, getCardBySlug, getCardMediaMeta, getSourceLabel, getYouTubeEmbedUrl, getYouTubeThumbnailUrl } from "@/lib/cards";
 
 describe("card detail", () => {
   it("returns a card by slug", () => {
@@ -26,8 +26,22 @@ describe("card detail", () => {
     );
   });
 
+  it("builds thumbnail and source metadata for video-enabled cards", () => {
+    const card = getCardBySlug("melt");
+    expect(card).toBeTruthy();
+    expect(getYouTubeThumbnailUrl(card?.youtube_url)).toBe("https://img.youtube.com/vi/o1jAMSQyVPc/hqdefault.jpg");
+    expect(getSourceLabel(card?.youtube_url)).toBe("YouTube");
+    expect(getCardMediaMeta(card!)).toMatchObject({
+      hasRichMedia: true,
+      videoLabel: "YouTube",
+      youtubeThumbnailUrl: "https://img.youtube.com/vi/o1jAMSQyVPc/hqdefault.jpg",
+    });
+  });
+
   it("ignores invalid or non-youtube urls", () => {
     expect(getYouTubeEmbedUrl("https://example.com/video")).toBeUndefined();
+    expect(getYouTubeThumbnailUrl("https://example.com/video")).toBeUndefined();
+    expect(getSourceLabel("https://example.com/video")).toBe("example.com");
     expect(getYouTubeEmbedUrl("https://www.youtube.com/watch?v=short")).toBeUndefined();
     expect(getYouTubeEmbedUrl("not-a-url")).toBeUndefined();
   });

--- a/src/app/cards/[slug]/page.tsx
+++ b/src/app/cards/[slug]/page.tsx
@@ -1,5 +1,10 @@
 import Link from "next/link";
-import { getCardBySlugAsync, getCardExternalLinks, getYouTubeEmbedUrl } from "@/lib/cards";
+import {
+  getCardBySlugAsync,
+  getCardExternalLinks,
+  getCardMediaMeta,
+  getYouTubeEmbedUrl,
+} from "@/lib/cards";
 import { listDecks } from "@/lib/decks";
 import { getProfileHref } from "@/lib/profiles";
 
@@ -28,6 +33,7 @@ export default async function CardDetail({ params }: Props) {
 
   const links = getCardExternalLinks(card);
   const embedUrl = getYouTubeEmbedUrl(card.youtube_url);
+  const media = getCardMediaMeta(card);
   const decks = await listDecks();
   const relatedDecks = decks.filter((deck) => deck.cards.includes(card.slug));
 
@@ -124,6 +130,18 @@ export default async function CardDetail({ params }: Props) {
                   <span className="text-[var(--terminal-muted)]">영상</span>
                   <span>{embedUrl ? "있음" : "없음"}</span>
                 </div>
+                {media.videoLabel && (
+                  <div className="flex items-center justify-between gap-4 border border-[var(--terminal-border)] px-3 py-2">
+                    <span className="text-[var(--terminal-muted)]">영상 소스</span>
+                    <span className="text-right">{media.videoLabel}</span>
+                  </div>
+                )}
+                {media.sourceLabel && (
+                  <div className="flex items-center justify-between gap-4 border border-[var(--terminal-border)] px-3 py-2">
+                    <span className="text-[var(--terminal-muted)]">원문 소스</span>
+                    <span className="text-right">{media.sourceLabel}</span>
+                  </div>
+                )}
               </div>
             </aside>
           </div>
@@ -141,15 +159,45 @@ export default async function CardDetail({ params }: Props) {
                     </a>
                   )}
                 </div>
-                <div className="overflow-hidden border border-[var(--terminal-border)] bg-black">
-                  <div className="relative aspect-video w-full">
-                    <iframe
-                      src={embedUrl}
-                      title={`${card.title} YouTube player`}
-                      className="absolute inset-0 h-full w-full"
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                      allowFullScreen
-                    />
+                <div className="grid gap-4 lg:grid-cols-[220px_minmax(0,1fr)]">
+                  {media.youtubeThumbnailUrl && (
+                    <a
+                      href={links.youtube}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="overflow-hidden border border-[var(--terminal-border)] bg-black"
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img src={media.youtubeThumbnailUrl} alt={`${card.title} thumbnail`} className="aspect-video h-full w-full object-cover" />
+                    </a>
+                  )}
+                  <div className="space-y-3">
+                    <div className="overflow-hidden border border-[var(--terminal-border)] bg-black">
+                      <div className="relative aspect-video w-full">
+                        <iframe
+                          src={embedUrl}
+                          title={`${card.title} YouTube player`}
+                          className="absolute inset-0 h-full w-full"
+                          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                          allowFullScreen
+                        />
+                      </div>
+                    </div>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <div className="border border-[var(--terminal-border)] px-4 py-3">
+                        <p className="text-xs uppercase tracking-[0.12em] text-[var(--terminal-muted)]">preview</p>
+                        <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">
+                          텍스트 링크 대신 썸네일과 임베드로 바로 맥락을 파악할 수 있어요.
+                        </p>
+                      </div>
+                      <div className="border border-[var(--terminal-border)] px-4 py-3">
+                        <p className="text-xs uppercase tracking-[0.12em] text-[var(--terminal-muted)]">source metadata</p>
+                        <p className="mt-2 text-sm leading-6 text-[var(--terminal-soft)]">
+                          영상 소스 {media.videoLabel ?? "unknown"}
+                          {media.sourceLabel ? ` · 원문 소스 ${media.sourceLabel}` : ""}
+                        </p>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </section>
@@ -188,6 +236,20 @@ export default async function CardDetail({ params }: Props) {
           <aside className="space-y-6">
             <section className="terminal-frame p-5">
               <h2 className="text-lg font-semibold">바로 가기</h2>
+              {media.hasSourceMeta && (
+                <div className="mt-4 grid gap-3 text-sm">
+                  <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
+                    <span className="text-[var(--terminal-muted)]">영상 소스</span>
+                    <span>{media.videoLabel ?? "unknown"}</span>
+                  </div>
+                  {media.sourceLabel && (
+                    <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
+                      <span className="text-[var(--terminal-muted)]">원문 소스</span>
+                      <span>{media.sourceLabel}</span>
+                    </div>
+                  )}
+                </div>
+              )}
               <div className="mt-4 flex flex-col gap-3 text-sm">
                 {links.source && (
                   <a href={links.source} target="_blank" rel="noreferrer" className="terminal-button text-center">

--- a/src/lib/cards.ts
+++ b/src/lib/cards.ts
@@ -155,7 +155,7 @@ export const getCardExternalLinks = (card: Card) => {
   };
 };
 
-export const getYouTubeEmbedUrl = (url?: string) => {
+export const getYouTubeVideoId = (url?: string) => {
   if (!url) return undefined;
 
   try {
@@ -177,8 +177,47 @@ export const getYouTubeEmbedUrl = (url?: string) => {
     }
 
     if (!videoId || !/^[A-Za-z0-9_-]{11}$/.test(videoId)) return undefined;
-    return `https://www.youtube.com/embed/${videoId}`;
+    return videoId;
   } catch {
     return undefined;
   }
+};
+
+export const getYouTubeEmbedUrl = (url?: string) => {
+  const videoId = getYouTubeVideoId(url);
+  return videoId ? `https://www.youtube.com/embed/${videoId}` : undefined;
+};
+
+export const getYouTubeThumbnailUrl = (url?: string) => {
+  const videoId = getYouTubeVideoId(url);
+  return videoId ? `https://img.youtube.com/vi/${videoId}/hqdefault.jpg` : undefined;
+};
+
+export const getSourceLabel = (url?: string) => {
+  if (!url) return undefined;
+
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+
+    if (host.includes("youtube.com") || host === "youtu.be") return "YouTube";
+    if (host.includes("nicovideo.jp")) return "Niconico";
+    return parsed.hostname.replace(/^www\./, "");
+  } catch {
+    return undefined;
+  }
+};
+
+export const getCardMediaMeta = (card: Card) => {
+  const youtubeThumbnailUrl = getYouTubeThumbnailUrl(card.youtube_url);
+  const sourceLabel = getSourceLabel(card.source_url);
+  const videoLabel = getSourceLabel(card.youtube_url);
+
+  return {
+    hasRichMedia: Boolean(youtubeThumbnailUrl),
+    youtubeThumbnailUrl,
+    sourceLabel,
+    videoLabel,
+    hasSourceMeta: Boolean(sourceLabel || videoLabel),
+  };
 };


### PR DESCRIPTION
## 🎵 변경 사항
- 카드 상세에 YouTube 썸네일 / richer preview treatment 추가
- 영상 소스 / 원문 소스 메타데이터 노출
- 카드 media helper 확장 및 테스트 보강
- 영상 없는 카드에서는 기존처럼 깔끔하게 유지

## 🎤 관련 이슈
- Closes #35

## 🎹 테스트
- [x] `pnpm typecheck`
- [x] `pnpm test`
