### PR TITLE
feat(discovery): add related decks and cards

### DIFF
--- a/__tests__/related.test.ts
+++ b/__tests__/related.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { cards } from "@/lib/cards";
+import { decks } from "@/lib/decks";
+import { getRelatedCards, getRelatedDecks } from "@/lib/related";
+
+describe("related discovery", () => {
+  it("finds related decks from shared tags/cards", () => {
+    const target = decks.find((deck) => deck.slug === "classic-miku");
+    expect(target).toBeTruthy();
+
+    const related = getRelatedDecks(target!, decks);
+    expect(related.map((deck) => deck.slug)).toContain("stage-hits");
+  });
+
+  it("finds related cards from shared metadata", () => {
+    const target = cards.find((card) => card.slug === "melt");
+    expect(target).toBeTruthy();
+
+    const related = getRelatedCards(target!, cards);
+    expect(related.length).toBeGreaterThan(0);
+    expect(related.some((card) => card.slug === "world-is-mine" || card.slug === "reverse-rainbow")).toBe(true);
+  });
+});

--- a/src/app/cards/[slug]/page.tsx
+++ b/src/app/cards/[slug]/page.tsx
@@ -5,8 +5,10 @@ import {
   getCardMediaMeta,
   getYouTubeEmbedUrl,
 } from "@/lib/cards";
+import { listCards } from "@/lib/cards";
 import { listDecks } from "@/lib/decks";
 import { getProfileHref } from "@/lib/profiles";
+import { getRelatedCards, getRelatedDecks } from "@/lib/related";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -35,7 +37,20 @@ export default async function CardDetail({ params }: Props) {
   const embedUrl = getYouTubeEmbedUrl(card.youtube_url);
   const media = getCardMediaMeta(card);
   const decks = await listDecks();
+  const allCards = await listCards();
   const relatedDecks = decks.filter((deck) => deck.cards.includes(card.slug));
+  const suggestedDecks = getRelatedDecks(
+    {
+      slug: `card-${card.slug}`,
+      name: card.title,
+      tags: card.tags,
+      cards: relatedDecks.flatMap((deck) => deck.cards),
+      authorHandle: card.authorHandle,
+      authorName: card.authorName,
+    },
+    decks.filter((deck) => !deck.cards.includes(card.slug)),
+  );
+  const relatedCards = getRelatedCards(card, allCards);
 
   return (
     <div className="min-h-screen text-white">
@@ -294,6 +309,59 @@ export default async function CardDetail({ params }: Props) {
                 ) : (
                   <div className="border border-[var(--terminal-border)] px-4 py-4 text-sm text-[var(--terminal-muted)]">
                     아직 이 카드를 담은 덱이 없어요. 덱을 새로 만들어 이 카드를 중심으로 묶을 수 있어요.
+                  </div>
+                )}
+              </div>
+            </section>
+
+            <section className="terminal-frame p-5">
+              <div className="flex items-center justify-between gap-4">
+                <h2 className="text-lg font-semibold">관련 카드</h2>
+                <Link href="/" className="text-sm text-[var(--terminal-soft)]">
+                  카드 탐색 →
+                </Link>
+              </div>
+              <div className="mt-4 space-y-3">
+                {relatedCards.length > 0 ? (
+                  relatedCards.map((item) => (
+                    <Link key={item.slug} href={`/cards/${item.slug}`} className="block border border-[var(--terminal-border)] px-4 py-4">
+                      <div className="flex items-center justify-between gap-3 text-xs text-[var(--terminal-muted)]">
+                        <span>{item.character}</span>
+                        <span className="uppercase">{item.type}</span>
+                      </div>
+                      <p className="mt-2 text-sm font-semibold">{item.title}</p>
+                      <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">{item.summary ?? item.whyItMatters ?? "가까운 맥락의 카드"}</p>
+                    </Link>
+                  ))
+                ) : (
+                  <div className="border border-[var(--terminal-border)] px-4 py-4 text-sm text-[var(--terminal-muted)]">
+                    아직 바로 이어 볼 만한 카드 추천이 없어요.
+                  </div>
+                )}
+              </div>
+            </section>
+
+            <section className="terminal-frame p-5">
+              <div className="flex items-center justify-between gap-4">
+                <h2 className="text-lg font-semibold">관련 덱</h2>
+                <Link href="/decks" className="text-sm text-[var(--terminal-soft)]">
+                  덱 탐색 →
+                </Link>
+              </div>
+              <div className="mt-4 space-y-3">
+                {suggestedDecks.length > 0 ? (
+                  suggestedDecks.map((deck) => (
+                    <Link key={deck.slug} href={`/decks/${deck.slug}`} className="block border border-[var(--terminal-border)] px-4 py-4">
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-sm font-semibold">{deck.name}</p>
+                        <span className="text-xs text-[var(--terminal-muted)]">{deck.cards.length} cards</span>
+                      </div>
+                      <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">{deck.shortPitch ?? deck.description}</p>
+                    </Link>
+                  ))
+                ) : (
+                  <div className="border border-[var(--terminal-border)] px-4 py-4 text-sm text-[var(--terminal-muted)]">
+                    아직 이 카드와 가까운 다른 덱 추천이 없어요.
                   </div>
                 )}
               </div>

--- a/src/app/decks/[slug]/page.tsx
+++ b/src/app/decks/[slug]/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import ShareDeckActions from "./ShareDeckActions";
-import { getCardBySlugAsync, type Card } from "@/lib/cards";
+import { getCardBySlugAsync, listCards, type Card } from "@/lib/cards";
 import { getDeckShareDescription, getDeckShareUrl } from "@/lib/deck-share";
-import { getDeckBySlugAsync } from "@/lib/decks";
+import { getDeckBySlugAsync, listDecks } from "@/lib/decks";
 import { getProfileHref } from "@/lib/profiles";
+import { getRelatedCards, getRelatedDecks } from "@/lib/related";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -69,6 +70,10 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
   const cards = (await Promise.all(deck.cards.map((cardSlug) => getCardBySlugAsync(cardSlug)))).filter(
     (card): card is Card => Boolean(card),
   );
+  const allDecks = await listDecks();
+  const allCards = await listCards();
+  const relatedDecks = getRelatedDecks(deck, allDecks);
+  const relatedCards = cards.length > 0 ? getRelatedCards(cards[0], allCards) : [];
 
   return (
     <div className="min-h-screen text-white">
@@ -223,7 +228,61 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
             </div>
           </article>
 
-          <aside className="terminal-frame p-5">
+          <aside className="space-y-6">
+            <div className="terminal-frame p-5">
+              <div className="flex items-center justify-between gap-4">
+                <h2 className="text-lg font-semibold">관련 덱</h2>
+                <Link href="/decks" className="text-sm text-[var(--terminal-soft)]">
+                  덱 탐색 →
+                </Link>
+              </div>
+              <div className="mt-4 space-y-3">
+                {relatedDecks.length > 0 ? (
+                  relatedDecks.map((item) => (
+                    <Link key={item.slug} href={`/decks/${item.slug}`} className="block border border-[var(--terminal-border)] px-4 py-4">
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-sm font-semibold">{item.name}</p>
+                        <span className="text-xs text-[var(--terminal-muted)]">{item.cards.length} cards</span>
+                      </div>
+                      <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">{item.shortPitch ?? item.description}</p>
+                    </Link>
+                  ))
+                ) : (
+                  <div className="border border-[var(--terminal-border)] px-4 py-4 text-sm text-[var(--terminal-muted)]">
+                    아직 이 덱과 가까운 다른 덱 추천이 없어요.
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="terminal-frame p-5">
+              <div className="flex items-center justify-between gap-4">
+                <h2 className="text-lg font-semibold">관련 카드</h2>
+                <Link href="/" className="text-sm text-[var(--terminal-soft)]">
+                  카드 탐색 →
+                </Link>
+              </div>
+              <div className="mt-4 space-y-3">
+                {relatedCards.length > 0 ? (
+                  relatedCards.map((item) => (
+                    <Link key={item.slug} href={`/cards/${item.slug}`} className="block border border-[var(--terminal-border)] px-4 py-4">
+                      <div className="flex items-center justify-between gap-3 text-xs text-[var(--terminal-muted)]">
+                        <span>{item.character}</span>
+                        <span className="uppercase">{item.type}</span>
+                      </div>
+                      <p className="mt-2 text-sm font-semibold">{item.title}</p>
+                      <p className="mt-2 text-sm leading-6 text-[var(--terminal-muted)]">{item.summary ?? item.whyItMatters ?? "가까운 맥락의 카드"}</p>
+                    </Link>
+                  ))
+                ) : (
+                  <div className="border border-[var(--terminal-border)] px-4 py-4 text-sm text-[var(--terminal-muted)]">
+                    아직 이 덱에서 바로 이어 볼 카드 추천이 없어요.
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="terminal-frame p-5">
             <div className="flex items-center justify-between gap-4">
               <h2 className="text-lg font-semibold">story map</h2>
               <Link href="/decks/new" className="text-sm text-[var(--terminal-soft)]">
@@ -249,6 +308,7 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
                 );
               })}
             </div>
+          </div>
           </aside>
         </section>
 

--- a/src/lib/related.ts
+++ b/src/lib/related.ts
@@ -1,0 +1,50 @@
+import type { Card } from "@/lib/cards";
+import type { Deck } from "@/lib/decks";
+
+const intersectionCount = (left: string[], right: string[]) => {
+  const rightSet = new Set(right);
+  return left.filter((item) => rightSet.has(item)).length;
+};
+
+export const getRelatedDecks = (target: Deck, allDecks: Deck[], limit = 3) => {
+  return allDecks
+    .filter((deck) => deck.slug !== target.slug)
+    .map((deck) => {
+      const sharedTags = intersectionCount(target.tags, deck.tags);
+      const sharedCards = intersectionCount(target.cards, deck.cards);
+      const sameAuthor = target.authorHandle && deck.authorHandle && target.authorHandle === deck.authorHandle ? 1 : 0;
+      const score = sharedTags * 3 + sharedCards * 4 + sameAuthor * 2;
+
+      return { deck, score, sharedTags, sharedCards };
+    })
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score || b.sharedCards - a.sharedCards || b.sharedTags - a.sharedTags || a.deck.name.localeCompare(b.deck.name))
+    .slice(0, limit)
+    .map((item) => item.deck);
+};
+
+export const getRelatedCards = (target: Card, allCards: Card[], limit = 4) => {
+  return allCards
+    .filter((card) => card.slug !== target.slug)
+    .map((card) => {
+      const sharedTags = intersectionCount(target.tags, card.tags);
+      const sameProducer = target.producer && card.producer && target.producer === card.producer ? 1 : 0;
+      const sameEra = target.era && card.era && target.era === card.era ? 1 : 0;
+      const sameCharacter = target.character === card.character ? 1 : 0;
+      const score = sharedTags * 3 + sameProducer * 3 + sameEra * 2 + sameCharacter * 2;
+
+      return { card, score, sharedTags, sameProducer, sameEra, sameCharacter };
+    })
+    .filter((item) => item.score > 0)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        b.sharedTags - a.sharedTags ||
+        b.sameProducer - a.sameProducer ||
+        b.sameEra - a.sameEra ||
+        b.sameCharacter - a.sameCharacter ||
+        a.card.title.localeCompare(b.card.title),
+    )
+    .slice(0, limit)
+    .map((item) => item.card);
+};


### PR DESCRIPTION
## 🎵 변경 사항
- 카드/덱 상세에 related decks / related cards discovery 섹션 추가
- shared tags/cards/metadata 기반 related helper 추가
- related discovery 테스트 추가

## 🎤 관련 이슈
- Closes #36

## 🎹 테스트
- [x] `pnpm typecheck`
- [x] `pnpm test`
