### PR TITLE
feat(content): add onboarding seed decks

### DIFF
--- a/__tests__/decks.test.ts
+++ b/__tests__/decks.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from "vitest";
 import { decks, getDeckBySlug, searchDecks } from "@/lib/decks";
 
 describe("decks library", () => {
-  it("loads deck seed", () => {
-    expect(decks.length).toBeGreaterThan(0);
+  it("loads onboarding-ready seed decks", () => {
+    expect(decks.length).toBeGreaterThanOrEqual(5);
+    expect(decks.filter((deck) => deck.featured).length).toBeGreaterThanOrEqual(3);
   });
 
   it("finds deck by slug", () => {

--- a/__tests__/related.test.ts
+++ b/__tests__/related.test.ts
@@ -9,7 +9,8 @@ describe("related discovery", () => {
     expect(target).toBeTruthy();
 
     const related = getRelatedDecks(target!, decks);
-    expect(related.map((deck) => deck.slug)).toContain("stage-hits");
+    expect(related.length).toBeGreaterThan(0);
+    expect(related.some((deck) => ["stage-hits", "niconico-explosion-2007", "emotion-arc"].includes(deck.slug))).toBe(true);
   });
 
   it("finds related cards from shared metadata", () => {

--- a/src/data/deck-details.ts
+++ b/src/data/deck-details.ts
@@ -70,4 +70,85 @@ export const deckDetails: Record<string, DeckDetailSeed> = {
       },
     },
   },
+  "niconico-explosion-2007": {
+    shortPitch: "초기 바이럴 폭발을 빠르게 체감하게 해주는 타임캡슐형 덱.",
+    introTitle: "2007년 니코니코 폭발기",
+    introBody:
+      "Vocaloid가 인터넷에서 어떻게 퍼지고, 어떤 카드들이 초반 대중 인지도를 밀어올렸는지 시간순 감각으로 묶은 덱이에요.",
+    readingGuide:
+      "초기 확산의 에너지를 느끼기 위해, 카드별 완성도보다 당시 인터넷 반응과 상징성을 먼저 떠올리며 읽어보세요.",
+    curatorNote:
+      "온보딩에서 '왜 이 문화가 빨리 커졌는가'를 한 번에 보여주는 쇼케이스 덱으로 설계했어요.",
+    featured: true,
+    authorHandle: "bini59",
+    authorName: "빈이",
+    cardNotes: {
+      melt: {
+        lead: "폭발의 기점",
+        note: "초기 확산을 논할 때 가장 먼저 호출되는 대표 카드라서 시대 감각의 기준점이 됩니다.",
+      },
+      "world-is-mine": {
+        lead: "캐릭터 소비의 가속",
+        note: "곡을 넘어 캐릭터 자체가 인터넷 밈과 팬덤 담론으로 번지는 지점을 보여줘요.",
+      },
+      "ievan-polkka": {
+        lead: "밈 확장의 증거",
+        note: "짧은 루프와 밈 친화성 덕분에 플랫폼 확산성을 설명하기 좋은 마지막 카드예요.",
+      },
+    },
+  },
+  "miku-meme-starter": {
+    shortPitch: "처음 보는 사람도 바로 반응할 수 있는 대중 인지도 중심의 스타터 덱.",
+    introTitle: "밈에서 시작하는 미쿠 입문",
+    introBody:
+      "설명보다 반응이 먼저 오는 카드들로 구성해, 신규 유저가 '이건 나도 안다'는 감각에서 자연스럽게 탐색을 시작하게 만들어요.",
+    readingGuide:
+      "정확한 역사보다 즉시 떠오르는 이미지와 밈, 반복 재생 포인트에 집중해서 가볍게 넘겨보면 좋아요.",
+    curatorNote:
+      "홈 첫인상에서 부담 없이 눌러볼 수 있는 온보딩 카드 묶음이 필요해서 만든 덱이에요.",
+    featured: false,
+    authorHandle: "miku",
+    authorName: "初音ミク",
+    cardNotes: {
+      "world-is-mine": {
+        lead: "캐릭터 밈의 중심",
+        note: "미쿠의 캐릭터성을 가장 대중적으로 각인시킨 카드라 스타터 덱의 첫머리에 잘 맞아요.",
+      },
+      "ievan-polkka": {
+        lead: "반복되는 인터넷 기억",
+        note: "짧고 강한 밈 회전력 덕분에 신규 유저에게도 즉시 설명이 통하는 카드예요.",
+      },
+      melt: {
+        lead: "밈에서 대표곡으로",
+        note: "밈 기반 진입 이후, 왜 대표곡 아카이브로 더 깊게 들어가야 하는지 자연스럽게 연결해줍니다.",
+      },
+    },
+  },
+  "emotion-arc": {
+    shortPitch: "감정선의 상승과 침잠을 따라가며 읽는 스토리형 큐레이션.",
+    introTitle: "감정선으로 묶은 미쿠 서사",
+    introBody:
+      "단순 인기순이 아니라 정서의 흐름을 따라 묶어, 덱이 하나의 읽기 경험이 될 수 있다는 점을 보여주는 예시예요.",
+    readingGuide:
+      "각 카드의 정보량보다 앞 카드의 감정이 다음 카드에서 어떻게 변주되는지에 집중해보세요.",
+    curatorNote:
+      "Voxie가 단순 데이터베이스가 아니라 '읽는 순서를 설계하는 제품'임을 보여주기 위해 만든 실험적인 덱이에요.",
+    featured: false,
+    authorHandle: "bini59",
+    authorName: "빈이",
+    cardNotes: {
+      melt: {
+        lead: "설렘의 출발",
+        note: "밝고 선명한 감정에서 시작하면 뒤 카드들의 대비가 더 선명하게 느껴져요.",
+      },
+      "rolling-girl": {
+        lead: "감정의 심화",
+        note: "중간 지점에서 서사를 깊게 눌러주며 덱 전체의 온도를 바꿔주는 역할을 합니다.",
+      },
+      "reverse-rainbow": {
+        lead: "잔향의 정리",
+        note: "마지막에는 감정을 완전히 끊지 않고 여운으로 정리해 다시 탐색으로 이어지게 만들어요.",
+      },
+    },
+  },
 };

--- a/src/data/decks.json
+++ b/src/data/decks.json
@@ -3,14 +3,35 @@
     "slug": "classic-miku",
     "name": "Classic Miku",
     "description": "초기 대표곡 모음",
-    "tags": ["classic", "miku"],
+    "tags": ["classic", "miku", "starter"],
     "cards": ["melt", "world-is-mine", "rolling-girl"]
   },
   {
     "slug": "stage-hits",
     "name": "Stage Hits",
     "description": "라이브에서 많이 불린 곡",
-    "tags": ["iconic", "live"],
+    "tags": ["iconic", "live", "performance"],
     "cards": ["melt", "ievan-polkka", "reverse-rainbow"]
+  },
+  {
+    "slug": "niconico-explosion-2007",
+    "name": "2007 NicoNico Explosion",
+    "description": "초기 니코니코 확산기를 보여주는 입문형 덱",
+    "tags": ["2007", "niconico", "classic"],
+    "cards": ["melt", "world-is-mine", "ievan-polkka"]
+  },
+  {
+    "slug": "miku-meme-starter",
+    "name": "Miku Meme Starter",
+    "description": "밈과 대중 인지도를 중심으로 보는 스타터 덱",
+    "tags": ["meme", "starter", "iconic"],
+    "cards": ["world-is-mine", "ievan-polkka", "melt"]
+  },
+  {
+    "slug": "emotion-arc",
+    "name": "Emotion Arc",
+    "description": "감정선 변화에 집중한 스토리형 큐레이션",
+    "tags": ["emotional", "story", "classic"],
+    "cards": ["melt", "rolling-girl", "reverse-rainbow"]
   }
 ]


### PR DESCRIPTION
## 🎵 변경 사항
- Voxie onboarding용 seed deck 5종 구성 추가
- 그중 3종을 featured/showcase 덱으로 정리
- deck seed 테스트를 onboarding 기준으로 보강
- 관련 추천 테스트를 확장된 seed deck 세트에 맞게 조정

## 🎤 관련 이슈
- Closes #37

## 🎹 테스트
- [x] `pnpm test`
- [x] `pnpm typecheck`
