### PR TITLE
feat(social): add lightweight curator actions

### DIFF
--- a/__tests__/social.test.ts
+++ b/__tests__/social.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { getDeckSocialMeta, getProfileSocialMeta } from "@/lib/social";
+
+describe("social metadata", () => {
+  it("returns seed social stats for known decks", () => {
+    expect(getDeckSocialMeta("classic-miku")).toEqual({ likes: 128, bookmarks: 44 });
+  });
+
+  it("returns follower stats for known curators", () => {
+    expect(getProfileSocialMeta("bini59").followers).toBeGreaterThan(0);
+  });
+});

--- a/src/app/decks/[slug]/SocialActions.tsx
+++ b/src/app/decks/[slug]/SocialActions.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type Props = {
+  initialLikes: number;
+  initialBookmarks: number;
+  curatorName?: string;
+  initialFollowers: number;
+};
+
+export default function SocialActions({ initialLikes, initialBookmarks, curatorName, initialFollowers }: Props) {
+  const [liked, setLiked] = useState(false);
+  const [bookmarked, setBookmarked] = useState(false);
+  const [followed, setFollowed] = useState(false);
+
+  const likes = useMemo(() => initialLikes + (liked ? 1 : 0), [initialLikes, liked]);
+  const bookmarks = useMemo(() => initialBookmarks + (bookmarked ? 1 : 0), [initialBookmarks, bookmarked]);
+  const followers = useMemo(() => initialFollowers + (followed ? 1 : 0), [initialFollowers, followed]);
+
+  return (
+    <div className="terminal-frame p-4">
+      <p className="text-sm font-semibold">가벼운 액션</p>
+      <p className="mt-2 text-xs leading-6 text-[var(--terminal-muted)]">좋아요, 북마크, 큐레이터 팔로우만 먼저 넣어서 반응은 남기되 시끄러운 커뮤니티 기능은 아직 열지 않았어요.</p>
+      <div className="mt-4 grid gap-2">
+        <button type="button" className="terminal-button w-full justify-between" onClick={() => setLiked((value) => !value)}>
+          <span>{liked ? "좋아요 취소" : "좋아요"}</span>
+          <span>{likes}</span>
+        </button>
+        <button type="button" className="terminal-button w-full justify-between" onClick={() => setBookmarked((value) => !value)}>
+          <span>{bookmarked ? "북마크 해제" : "북마크"}</span>
+          <span>{bookmarks}</span>
+        </button>
+        <button type="button" className="terminal-button w-full justify-between" onClick={() => setFollowed((value) => !value)}>
+          <span>{followed ? `${curatorName ?? "큐레이터"} 언팔로우` : `${curatorName ?? "큐레이터"} 팔로우`}</span>
+          <span>{followers}</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/decks/[slug]/page.tsx
+++ b/src/app/decks/[slug]/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import ShareDeckActions from "./ShareDeckActions";
+import SocialActions from "./SocialActions";
 import { getCardBySlugAsync, listCards, type Card } from "@/lib/cards";
 import { getDeckShareDescription, getDeckShareUrl } from "@/lib/deck-share";
 import { getDeckBySlugAsync, listDecks } from "@/lib/decks";
 import { getProfileHref } from "@/lib/profiles";
 import { getRelatedCards, getRelatedDecks } from "@/lib/related";
+import { getDeckSocialMeta, getProfileSocialMeta } from "@/lib/social";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -74,6 +76,8 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
   const allCards = await listCards();
   const relatedDecks = getRelatedDecks(deck, allDecks);
   const relatedCards = cards.length > 0 ? getRelatedCards(cards[0], allCards) : [];
+  const social = getDeckSocialMeta(deck.slug);
+  const profileSocial = deck.authorHandle ? getProfileSocialMeta(deck.authorHandle) : { followers: 0 };
 
   return (
     <div className="min-h-screen text-white">
@@ -196,7 +200,15 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
             )}
           </article>
 
-          <ShareDeckActions title={deck.name} url={shareUrl} />
+          <div className="space-y-6">
+            <ShareDeckActions title={deck.name} url={shareUrl} />
+            <SocialActions
+              initialLikes={social.likes}
+              initialBookmarks={social.bookmarks}
+              curatorName={deck.authorName}
+              initialFollowers={profileSocial.followers}
+            />
+          </div>
         </section>
 
         <section className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">

--- a/src/app/users/[handle]/FollowCuratorButton.tsx
+++ b/src/app/users/[handle]/FollowCuratorButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = {
+  name: string;
+  initialFollowers: number;
+};
+
+export default function FollowCuratorButton({ name, initialFollowers }: Props) {
+  const [followed, setFollowed] = useState(false);
+  const followers = initialFollowers + (followed ? 1 : 0);
+
+  return (
+    <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+      <button type="button" className="terminal-button w-full sm:w-auto" onClick={() => setFollowed((value) => !value)}>
+        {followed ? `${name} 언팔로우` : `${name} 팔로우`}
+      </button>
+      <span className="text-sm text-[var(--terminal-muted)]">팔로워 {followers}</span>
+    </div>
+  );
+}

--- a/src/app/users/[handle]/page.tsx
+++ b/src/app/users/[handle]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from "next/navigation";
 import { listCards } from "@/lib/cards";
 import { listDecks } from "@/lib/decks";
 import { getProfileByHandle } from "@/lib/profiles";
+import { getProfileSocialMeta } from "@/lib/social";
+import FollowCuratorButton from "./FollowCuratorButton";
 
 type Props = {
   params: Promise<{ handle: string }>;
@@ -17,6 +19,7 @@ export default async function UserProfilePage({ params }: Props) {
   const [cards, decks] = await Promise.all([listCards(), listDecks()]);
   const authoredCards = cards.filter((card) => card.authorHandle === handle);
   const authoredDecks = decks.filter((deck) => deck.authorHandle === handle);
+  const social = getProfileSocialMeta(handle);
 
   return (
     <div className="min-h-screen text-white">
@@ -34,7 +37,9 @@ export default async function UserProfilePage({ params }: Props) {
                 <span>@{profile.handle}</span>
                 <span>{authoredCards.length} cards</span>
                 <span>{authoredDecks.length} decks</span>
+                <span>{social.followers} followers</span>
               </div>
+              <FollowCuratorButton name={profile.name} initialFollowers={social.followers} />
             </div>
 
             <aside className="terminal-frame p-4">
@@ -47,6 +52,10 @@ export default async function UserProfilePage({ params }: Props) {
                 <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
                   <span className="text-[var(--terminal-muted)]">작성 덱</span>
                   <span>{authoredDecks.length}</span>
+                </div>
+                <div className="flex items-center justify-between border border-[var(--terminal-border)] px-3 py-2">
+                  <span className="text-[var(--terminal-muted)]">팔로워</span>
+                  <span>{social.followers}</span>
                 </div>
               </div>
             </aside>

--- a/src/lib/social.ts
+++ b/src/lib/social.ts
@@ -1,0 +1,29 @@
+export type DeckSocialMeta = {
+  likes: number;
+  bookmarks: number;
+};
+
+export type ProfileSocialMeta = {
+  followers: number;
+};
+
+const deckSocialSeed: Record<string, DeckSocialMeta> = {
+  "classic-miku": { likes: 128, bookmarks: 44 },
+  "stage-hits": { likes: 97, bookmarks: 31 },
+  "niconico-explosion-2007": { likes: 76, bookmarks: 29 },
+  "miku-meme-starter": { likes: 63, bookmarks: 25 },
+  "emotion-arc": { likes: 54, bookmarks: 22 },
+};
+
+const profileSocialSeed: Record<string, ProfileSocialMeta> = {
+  bini59: { followers: 142 },
+  miku: { followers: 256 },
+};
+
+export const getDeckSocialMeta = (slug: string): DeckSocialMeta => {
+  return deckSocialSeed[slug] ?? { likes: 0, bookmarks: 0 };
+};
+
+export const getProfileSocialMeta = (handle: string): ProfileSocialMeta => {
+  return profileSocialSeed[handle] ?? { followers: 0 };
+};


### PR DESCRIPTION
## 🎵 변경 사항
- 덱 상세에 lightweight social actions 추가 (좋아요 / 북마크 / 큐레이터 팔로우)
- 프로필 페이지에 follow CTA와 follower count 추가
- social seed metadata / 테스트 추가
- 무거운 댓글/토론 시스템 없이 가벼운 반응 루프만 제공

## 🎤 관련 이슈
- Closes #38

## 🎹 테스트
- [x] `pnpm typecheck`
- [x] `pnpm test`
