### PR TITLE
feat(social): persist deck likes and bookmarks

### DIFF
--- a/__tests__/social-actions.test.ts
+++ b/__tests__/social-actions.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe("social actions", () => {
+  it("returns an auth error when unauthenticated users try to like a deck", async () => {
+    vi.doMock("@/lib/authored-content", () => ({
+      requireCurrentAuthoredProfile: () => Promise.resolve({ error: "로그인이 필요해요. 먼저 Voxie 계정으로 로그인해 주세요." }),
+    }));
+
+    const { toggleDeckLike } = await import("@/lib/actions/social");
+    await expect(toggleDeckLike("classic-miku")).resolves.toEqual({
+      success: false,
+      error: "로그인이 필요해요. 먼저 Voxie 계정으로 로그인해 주세요.",
+    });
+  });
+
+  it("creates a like when the viewer has not liked the deck yet", async () => {
+    const deckMaybeSingle = vi.fn().mockResolvedValue({ data: { id: "deck-1" }, error: null });
+    const existingMaybeSingle = vi.fn().mockResolvedValue({ data: null });
+    const likeInsert = vi.fn().mockResolvedValue({ error: null });
+
+    const from = vi.fn((table: string) => {
+      if (table === "decks") {
+        return { select: () => ({ eq: () => ({ maybeSingle: deckMaybeSingle }) }) };
+      }
+      if (table === "deck_likes") {
+        return {
+          select: () => ({ eq: () => ({ eq: () => ({ maybeSingle: existingMaybeSingle }) }) }),
+          insert: likeInsert,
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    vi.doMock("next/cache", () => ({ revalidatePath: vi.fn() }));
+    vi.doMock("@/lib/authored-content", () => ({
+      requireCurrentAuthoredProfile: () =>
+        Promise.resolve({ identity: { userId: "user-1", handle: "bini59", name: "빈이" }, user: { id: "user-1" } }),
+    }));
+    vi.doMock("@/lib/supabase/server", () => ({
+      createSupabaseServerClient: () => Promise.resolve({ from }),
+    }));
+
+    const { toggleDeckLike } = await import("@/lib/actions/social");
+    await expect(toggleDeckLike("classic-miku")).resolves.toEqual({ success: true, liked: true });
+    expect(likeInsert).toHaveBeenCalledWith({ deck_id: "deck-1", user_id: "user-1" });
+  });
+
+  it("removes a bookmark when the viewer already bookmarked the deck", async () => {
+    const deckMaybeSingle = vi.fn().mockResolvedValue({ data: { id: "deck-1" }, error: null });
+    const existingMaybeSingle = vi.fn().mockResolvedValue({ data: { id: "bookmark-1" } });
+    const deleteEq = vi.fn().mockResolvedValue({ error: null });
+
+    const from = vi.fn((table: string) => {
+      if (table === "decks") {
+        return { select: () => ({ eq: () => ({ maybeSingle: deckMaybeSingle }) }) };
+      }
+      if (table === "deck_bookmarks") {
+        return {
+          select: () => ({ eq: () => ({ eq: () => ({ maybeSingle: existingMaybeSingle }) }) }),
+          delete: () => ({ eq: deleteEq }),
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    vi.doMock("next/cache", () => ({ revalidatePath: vi.fn() }));
+    vi.doMock("@/lib/authored-content", () => ({
+      requireCurrentAuthoredProfile: () =>
+        Promise.resolve({ identity: { userId: "user-1", handle: "bini59", name: "빈이" }, user: { id: "user-1" } }),
+    }));
+    vi.doMock("@/lib/supabase/server", () => ({
+      createSupabaseServerClient: () => Promise.resolve({ from }),
+    }));
+
+    const { toggleDeckBookmark } = await import("@/lib/actions/social");
+    await expect(toggleDeckBookmark("classic-miku")).resolves.toEqual({ success: true, bookmarked: false });
+    expect(deleteEq).toHaveBeenCalledWith("id", "bookmark-1");
+  });
+});

--- a/__tests__/social.test.ts
+++ b/__tests__/social.test.ts
@@ -1,12 +1,69 @@
-import { describe, expect, it } from "vitest";
-import { getDeckSocialMeta, getProfileSocialMeta } from "@/lib/social";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
 
 describe("social metadata", () => {
-  it("returns seed social stats for known decks", () => {
-    expect(getDeckSocialMeta("classic-miku")).toEqual({ likes: 128, bookmarks: 44 });
+  it("returns seed social stats when Supabase is unavailable", async () => {
+    vi.doMock("@/lib/supabase/server", () => ({
+      createSupabaseServerClient: () => Promise.resolve(null),
+    }));
+    vi.doMock("@/lib/auth", () => ({
+      getCurrentUser: () => Promise.resolve(null),
+    }));
+
+    const { getDeckSocialMeta } = await import("@/lib/social");
+
+    await expect(getDeckSocialMeta("classic-miku")).resolves.toEqual({
+      likes: 128,
+      bookmarks: 44,
+      viewerHasLiked: false,
+      viewerHasBookmarked: false,
+      requiresAuth: true,
+    });
   });
 
-  it("returns follower stats for known curators", () => {
+  it("returns persisted social state for the current user when Supabase is available", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({ data: { id: "deck-1" } });
+    const likeEqDeck = vi.fn().mockResolvedValue({ data: [{ user_id: "user-1" }, { user_id: "user-2" }] });
+    const bookmarkEqDeck = vi.fn().mockResolvedValue({ data: [{ user_id: "user-1" }] });
+    const deckEqSlug = vi.fn(() => ({ maybeSingle }));
+
+    const from = vi.fn((table: string) => {
+      if (table === "decks") {
+        return { select: () => ({ eq: deckEqSlug }) };
+      }
+      if (table === "deck_likes") {
+        return { select: () => ({ eq: likeEqDeck }) };
+      }
+      if (table === "deck_bookmarks") {
+        return { select: () => ({ eq: bookmarkEqDeck }) };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createSupabaseServerClient: () => Promise.resolve({ from }),
+    }));
+    vi.doMock("@/lib/auth", () => ({
+      getCurrentUser: () => Promise.resolve({ id: "user-1" }),
+    }));
+
+    const { getDeckSocialMeta } = await import("@/lib/social");
+
+    await expect(getDeckSocialMeta("classic-miku")).resolves.toEqual({
+      likes: 2,
+      bookmarks: 1,
+      viewerHasLiked: true,
+      viewerHasBookmarked: true,
+      requiresAuth: false,
+    });
+  });
+
+  it("returns follower stats for known curators", async () => {
+    const { getProfileSocialMeta } = await import("@/lib/social");
     expect(getProfileSocialMeta("bini59").followers).toBeGreaterThan(0);
   });
 });

--- a/src/app/decks/[slug]/SocialActions.tsx
+++ b/src/app/decks/[slug]/SocialActions.tsx
@@ -1,41 +1,116 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useMemo, useState, useTransition } from "react";
+import { toggleDeckBookmark, toggleDeckLike } from "@/lib/actions/social";
 
 type Props = {
+  slug: string;
   initialLikes: number;
   initialBookmarks: number;
+  initiallyLiked: boolean;
+  initiallyBookmarked: boolean;
   curatorName?: string;
   initialFollowers: number;
+  requiresAuth: boolean;
 };
 
-export default function SocialActions({ initialLikes, initialBookmarks, curatorName, initialFollowers }: Props) {
-  const [liked, setLiked] = useState(false);
-  const [bookmarked, setBookmarked] = useState(false);
+export default function SocialActions({
+  slug,
+  initialLikes,
+  initialBookmarks,
+  initiallyLiked,
+  initiallyBookmarked,
+  curatorName,
+  initialFollowers,
+  requiresAuth,
+}: Props) {
+  const [liked, setLiked] = useState(initiallyLiked);
+  const [bookmarked, setBookmarked] = useState(initiallyBookmarked);
   const [followed, setFollowed] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [status, setStatus] = useState<string | null>(null);
 
-  const likes = useMemo(() => initialLikes + (liked ? 1 : 0), [initialLikes, liked]);
-  const bookmarks = useMemo(() => initialBookmarks + (bookmarked ? 1 : 0), [initialBookmarks, bookmarked]);
+  const likes = useMemo(() => initialLikes + (liked ? 1 : 0) - (initiallyLiked ? 1 : 0), [initialLikes, liked, initiallyLiked]);
+  const bookmarks = useMemo(
+    () => initialBookmarks + (bookmarked ? 1 : 0) - (initiallyBookmarked ? 1 : 0),
+    [initialBookmarks, bookmarked, initiallyBookmarked],
+  );
   const followers = useMemo(() => initialFollowers + (followed ? 1 : 0), [initialFollowers, followed]);
+
+  const handleLike = () => {
+    startTransition(async () => {
+      const previous = liked;
+      setStatus(null);
+      setLiked(!previous);
+      const result = await toggleDeckLike(slug);
+      if (!result.success) {
+        setLiked(previous);
+        setStatus(result.error ?? "좋아요 상태를 저장하지 못했어요.");
+        return;
+      }
+      setLiked(Boolean(result.liked));
+    });
+  };
+
+  const handleBookmark = () => {
+    startTransition(async () => {
+      const previous = bookmarked;
+      setStatus(null);
+      setBookmarked(!previous);
+      const result = await toggleDeckBookmark(slug);
+      if (!result.success) {
+        setBookmarked(previous);
+        setStatus(result.error ?? "북마크 상태를 저장하지 못했어요.");
+        return;
+      }
+      setBookmarked(Boolean(result.bookmarked));
+    });
+  };
 
   return (
     <div className="terminal-frame p-4">
       <p className="text-sm font-semibold">가벼운 액션</p>
-      <p className="mt-2 text-xs leading-6 text-[var(--terminal-muted)]">좋아요, 북마크, 큐레이터 팔로우만 먼저 넣어서 반응은 남기되 시끄러운 커뮤니티 기능은 아직 열지 않았어요.</p>
+      <p className="mt-2 text-xs leading-6 text-[var(--terminal-muted)]">
+        이제 좋아요와 북마크는 로그인한 사용자 기준으로 실제 저장돼요. 팔로우는 아직 다음 단계에서 이어집니다.
+      </p>
+
+      {requiresAuth && (
+        <div className="mt-4 border border-[var(--terminal-border)] px-3 py-3 text-xs leading-6 text-[var(--terminal-soft)]">
+          반응을 저장하려면 먼저 로그인해 주세요. <Link href="/auth" className="underline underline-offset-4">로그인하러 가기 →</Link>
+        </div>
+      )}
+
       <div className="mt-4 grid gap-2">
-        <button type="button" className="terminal-button w-full justify-between" onClick={() => setLiked((value) => !value)}>
+        <button
+          type="button"
+          className="terminal-button w-full justify-between"
+          onClick={handleLike}
+          disabled={pending}
+        >
           <span>{liked ? "좋아요 취소" : "좋아요"}</span>
           <span>{likes}</span>
         </button>
-        <button type="button" className="terminal-button w-full justify-between" onClick={() => setBookmarked((value) => !value)}>
+        <button
+          type="button"
+          className="terminal-button w-full justify-between"
+          onClick={handleBookmark}
+          disabled={pending}
+        >
           <span>{bookmarked ? "북마크 해제" : "북마크"}</span>
           <span>{bookmarks}</span>
         </button>
-        <button type="button" className="terminal-button w-full justify-between" onClick={() => setFollowed((value) => !value)}>
+        <button
+          type="button"
+          className="terminal-button w-full justify-between"
+          onClick={() => setFollowed((value) => !value)}
+        >
           <span>{followed ? `${curatorName ?? "큐레이터"} 언팔로우` : `${curatorName ?? "큐레이터"} 팔로우`}</span>
           <span>{followers}</span>
         </button>
       </div>
+
+      {status && <p className="mt-3 text-xs leading-6 text-[var(--terminal-soft)]">{status}</p>}
     </div>
   );
 }

--- a/src/app/decks/[slug]/page.tsx
+++ b/src/app/decks/[slug]/page.tsx
@@ -76,7 +76,7 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
   const allCards = await listCards();
   const relatedDecks = getRelatedDecks(deck, allDecks);
   const relatedCards = cards.length > 0 ? getRelatedCards(cards[0], allCards) : [];
-  const social = getDeckSocialMeta(deck.slug);
+  const social = await getDeckSocialMeta(deck.slug);
   const profileSocial = deck.authorHandle ? getProfileSocialMeta(deck.authorHandle) : { followers: 0 };
 
   return (
@@ -203,10 +203,14 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
           <div className="space-y-6">
             <ShareDeckActions title={deck.name} url={shareUrl} />
             <SocialActions
+              slug={deck.slug}
               initialLikes={social.likes}
               initialBookmarks={social.bookmarks}
+              initiallyLiked={social.viewerHasLiked}
+              initiallyBookmarked={social.viewerHasBookmarked}
               curatorName={deck.authorName}
               initialFollowers={profileSocial.followers}
+              requiresAuth={social.requiresAuth}
             />
           </div>
         </section>

--- a/src/lib/actions/social.ts
+++ b/src/lib/actions/social.ts
@@ -1,0 +1,92 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireCurrentAuthoredProfile } from "@/lib/authored-content";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+async function requireDeckId(slug: string) {
+  const supabase = await createSupabaseServerClient();
+  if (!supabase) {
+    return { error: "Supabase가 아직 연결되지 않았어요. 반응 저장은 잠시 후 다시 시도해 주세요." } as const;
+  }
+
+  const { data: deck, error } = await (supabase.from("decks") as any).select("id").eq("slug", slug).maybeSingle();
+
+  if (error || !deck) {
+    return { error: "대상 덱을 찾지 못했어요." } as const;
+  }
+
+  return { supabase, deckId: deck.id } as const;
+}
+
+export async function toggleDeckLike(slug: string) {
+  const authored = await requireCurrentAuthoredProfile();
+  if ("error" in authored) {
+    return { success: false, error: authored.error };
+  }
+
+  const resolved = await requireDeckId(slug);
+  if ("error" in resolved) {
+    return { success: false, error: resolved.error };
+  }
+
+  const { supabase, deckId } = resolved;
+  const { data: existing } = await (supabase.from("deck_likes") as any)
+    .select("id")
+    .eq("deck_id", deckId)
+    .eq("user_id", authored.identity.userId)
+    .maybeSingle();
+
+  if (existing) {
+    const { error } = await (supabase.from("deck_likes") as any).delete().eq("id", existing.id);
+    if (error) return { success: false, error: error.message };
+    revalidatePath(`/decks/${slug}`);
+    return { success: true, liked: false };
+  }
+
+  const { error } = await (supabase.from("deck_likes") as any).insert({
+    deck_id: deckId,
+    user_id: authored.identity.userId,
+  });
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/decks/${slug}`);
+  return { success: true, liked: true };
+}
+
+export async function toggleDeckBookmark(slug: string) {
+  const authored = await requireCurrentAuthoredProfile();
+  if ("error" in authored) {
+    return { success: false, error: authored.error };
+  }
+
+  const resolved = await requireDeckId(slug);
+  if ("error" in resolved) {
+    return { success: false, error: resolved.error };
+  }
+
+  const { supabase, deckId } = resolved;
+  const { data: existing } = await (supabase.from("deck_bookmarks") as any)
+    .select("id")
+    .eq("deck_id", deckId)
+    .eq("user_id", authored.identity.userId)
+    .maybeSingle();
+
+  if (existing) {
+    const { error } = await (supabase.from("deck_bookmarks") as any).delete().eq("id", existing.id);
+    if (error) return { success: false, error: error.message };
+    revalidatePath(`/decks/${slug}`);
+    return { success: true, bookmarked: false };
+  }
+
+  const { error } = await (supabase.from("deck_bookmarks") as any).insert({
+    deck_id: deckId,
+    user_id: authored.identity.userId,
+  });
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/decks/${slug}`);
+  return { success: true, bookmarked: true };
+}

--- a/src/lib/social.ts
+++ b/src/lib/social.ts
@@ -1,13 +1,19 @@
+import { getCurrentUser } from "@/lib/auth";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
 export type DeckSocialMeta = {
   likes: number;
   bookmarks: number;
+  viewerHasLiked: boolean;
+  viewerHasBookmarked: boolean;
+  requiresAuth: boolean;
 };
 
 export type ProfileSocialMeta = {
   followers: number;
 };
 
-const deckSocialSeed: Record<string, DeckSocialMeta> = {
+const deckSocialSeed: Record<string, { likes: number; bookmarks: number }> = {
   "classic-miku": { likes: 128, bookmarks: 44 },
   "stage-hits": { likes: 97, bookmarks: 31 },
   "niconico-explosion-2007": { likes: 76, bookmarks: 29 },
@@ -20,10 +26,51 @@ const profileSocialSeed: Record<string, ProfileSocialMeta> = {
   miku: { followers: 256 },
 };
 
-export const getDeckSocialMeta = (slug: string): DeckSocialMeta => {
+export const getDeckSeedSocialMeta = (slug: string) => {
   return deckSocialSeed[slug] ?? { likes: 0, bookmarks: 0 };
 };
 
 export const getProfileSocialMeta = (handle: string): ProfileSocialMeta => {
   return profileSocialSeed[handle] ?? { followers: 0 };
+};
+
+export const getDeckSocialMeta = async (slug: string): Promise<DeckSocialMeta> => {
+  const seed = getDeckSeedSocialMeta(slug);
+  const supabase = await createSupabaseServerClient();
+  const user = await getCurrentUser();
+
+  if (!supabase) {
+    return {
+      likes: seed.likes,
+      bookmarks: seed.bookmarks,
+      viewerHasLiked: false,
+      viewerHasBookmarked: false,
+      requiresAuth: true,
+    };
+  }
+
+  const { data: deck } = await (supabase.from("decks") as any).select("id").eq("slug", slug).maybeSingle();
+
+  if (!deck) {
+    return {
+      likes: seed.likes,
+      bookmarks: seed.bookmarks,
+      viewerHasLiked: false,
+      viewerHasBookmarked: false,
+      requiresAuth: !user,
+    };
+  }
+
+  const [{ data: likes }, { data: bookmarks }] = await Promise.all([
+    (supabase.from("deck_likes") as any).select("user_id").eq("deck_id", deck.id),
+    (supabase.from("deck_bookmarks") as any).select("user_id").eq("deck_id", deck.id),
+  ]);
+
+  return {
+    likes: likes?.length ?? seed.likes,
+    bookmarks: bookmarks?.length ?? seed.bookmarks,
+    viewerHasLiked: Boolean(user && likes?.some((entry: { user_id: string }) => entry.user_id === user.id)),
+    viewerHasBookmarked: Boolean(user && bookmarks?.some((entry: { user_id: string }) => entry.user_id === user.id)),
+    requiresAuth: !user,
+  };
 };

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -117,6 +117,46 @@ export interface Database {
           created_at?: string
         }
       }
+      deck_likes: {
+        Row: {
+          id: string
+          deck_id: string
+          user_id: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          deck_id: string
+          user_id: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          deck_id?: string
+          user_id?: string
+          created_at?: string
+        }
+      }
+      deck_bookmarks: {
+        Row: {
+          id: string
+          deck_id: string
+          user_id: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          deck_id: string
+          user_id: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          deck_id?: string
+          user_id?: string
+          created_at?: string
+        }
+      }
     }
     Views: {
       [_ in never]: never

--- a/supabase/migrations/004_deck_reactions.sql
+++ b/supabase/migrations/004_deck_reactions.sql
@@ -1,0 +1,41 @@
+create table if not exists public.deck_likes (
+  id uuid primary key default gen_random_uuid(),
+  deck_id uuid not null references public.decks(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique(deck_id, user_id)
+);
+
+create table if not exists public.deck_bookmarks (
+  id uuid primary key default gen_random_uuid(),
+  deck_id uuid not null references public.decks(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique(deck_id, user_id)
+);
+
+create index if not exists deck_likes_deck_id_idx on public.deck_likes(deck_id);
+create index if not exists deck_likes_user_id_idx on public.deck_likes(user_id);
+create index if not exists deck_bookmarks_deck_id_idx on public.deck_bookmarks(deck_id);
+create index if not exists deck_bookmarks_user_id_idx on public.deck_bookmarks(user_id);
+
+alter table public.deck_likes enable row level security;
+alter table public.deck_bookmarks enable row level security;
+
+create policy "Allow public read access on deck_likes" on public.deck_likes
+  for select using (true);
+
+create policy "Allow public read access on deck_bookmarks" on public.deck_bookmarks
+  for select using (true);
+
+create policy "Allow authenticated users to like decks" on public.deck_likes
+  for insert to authenticated with check (auth.uid() = user_id);
+
+create policy "Allow authenticated users to unlike their deck likes" on public.deck_likes
+  for delete to authenticated using (auth.uid() = user_id);
+
+create policy "Allow authenticated users to bookmark decks" on public.deck_bookmarks
+  for insert to authenticated with check (auth.uid() = user_id);
+
+create policy "Allow authenticated users to remove their deck bookmarks" on public.deck_bookmarks
+  for delete to authenticated using (auth.uid() = user_id);


### PR DESCRIPTION
## 🎵 변경 사항
- deck likes / bookmarks 저장용 Supabase schema + RLS 정책 추가
- deck detail에서 like / bookmark를 authenticated user 기준 실제 저장형으로 전환
- deck social meta를 DB 기반 count + viewer state로 읽도록 확장
- 로그인 안 된 상태에서는 social save CTA를 auth entrypoint로 연결
- social persistence 테스트 추가

## 🎤 관련 이슈
- Closes #52

## 🎹 테스트
- [x] `pnpm typecheck`
- [x] `pnpm test`
