### PR TITLE
feat(social): persist curator follows

### DIFF
--- a/__tests__/social-actions.test.ts
+++ b/__tests__/social-actions.test.ts
@@ -81,4 +81,45 @@ describe("social actions", () => {
     await expect(toggleDeckBookmark("classic-miku")).resolves.toEqual({ success: true, bookmarked: false });
     expect(deleteEq).toHaveBeenCalledWith("id", "bookmark-1");
   });
+
+  it("creates a follow when the viewer has not followed the curator yet", async () => {
+    const existingMaybeSingle = vi.fn().mockResolvedValue({ data: null });
+    const followInsert = vi.fn().mockResolvedValue({ error: null });
+
+    const from = vi.fn((table: string) => {
+      if (table === "curator_follows") {
+        return {
+          select: () => ({ eq: () => ({ eq: () => ({ maybeSingle: existingMaybeSingle }) }) }),
+          insert: followInsert,
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    vi.doMock("next/cache", () => ({ revalidatePath: vi.fn() }));
+    vi.doMock("@/lib/authored-content", () => ({
+      requireCurrentAuthoredProfile: () =>
+        Promise.resolve({ identity: { userId: "user-1", handle: "bini59", name: "빈이" }, user: { id: "user-1" } }),
+    }));
+    vi.doMock("@/lib/supabase/server", () => ({
+      createSupabaseServerClient: () => Promise.resolve({ from }),
+    }));
+
+    const { toggleCuratorFollow } = await import("@/lib/actions/social");
+    await expect(toggleCuratorFollow("miku")).resolves.toEqual({ success: true, followed: true });
+    expect(followInsert).toHaveBeenCalledWith({ curator_handle: "miku", user_id: "user-1" });
+  });
+
+  it("prevents users from following themselves", async () => {
+    vi.doMock("@/lib/authored-content", () => ({
+      requireCurrentAuthoredProfile: () =>
+        Promise.resolve({ identity: { userId: "user-1", handle: "bini59", name: "빈이" }, user: { id: "user-1" } }),
+    }));
+
+    const { toggleCuratorFollow } = await import("@/lib/actions/social");
+    await expect(toggleCuratorFollow("bini59")).resolves.toEqual({
+      success: false,
+      error: "자기 자신은 팔로우할 수 없어요.",
+    });
+  });
 });

--- a/__tests__/social.test.ts
+++ b/__tests__/social.test.ts
@@ -62,8 +62,43 @@ describe("social metadata", () => {
     });
   });
 
-  it("returns follower stats for known curators", async () => {
+  it("returns follower seed stats when Supabase is unavailable", async () => {
+    vi.doMock("@/lib/supabase/server", () => ({
+      createSupabaseServerClient: () => Promise.resolve(null),
+    }));
+    vi.doMock("@/lib/auth", () => ({
+      getCurrentUser: () => Promise.resolve(null),
+    }));
+
     const { getProfileSocialMeta } = await import("@/lib/social");
-    expect(getProfileSocialMeta("bini59").followers).toBeGreaterThan(0);
+    await expect(getProfileSocialMeta("bini59")).resolves.toEqual({
+      followers: 142,
+      viewerIsFollowing: false,
+      requiresAuth: true,
+    });
+  });
+
+  it("returns persisted follow state for the current user on curator profiles", async () => {
+    const followEqHandle = vi.fn().mockResolvedValue({ data: [{ user_id: "user-1" }, { user_id: "user-2" }] });
+    const from = vi.fn((table: string) => {
+      if (table === "curator_follows") {
+        return { select: () => ({ eq: followEqHandle }) };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createSupabaseServerClient: () => Promise.resolve({ from }),
+    }));
+    vi.doMock("@/lib/auth", () => ({
+      getCurrentUser: () => Promise.resolve({ id: "user-1" }),
+    }));
+
+    const { getProfileSocialMeta } = await import("@/lib/social");
+    await expect(getProfileSocialMeta("bini59")).resolves.toEqual({
+      followers: 2,
+      viewerIsFollowing: true,
+      requiresAuth: false,
+    });
   });
 });

--- a/src/app/decks/[slug]/SocialActions.tsx
+++ b/src/app/decks/[slug]/SocialActions.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useState, useTransition } from "react";
-import { toggleDeckBookmark, toggleDeckLike } from "@/lib/actions/social";
+import { toggleCuratorFollow, toggleDeckBookmark, toggleDeckLike } from "@/lib/actions/social";
 
 type Props = {
   slug: string;
@@ -10,9 +10,12 @@ type Props = {
   initialBookmarks: number;
   initiallyLiked: boolean;
   initiallyBookmarked: boolean;
+  curatorHandle?: string;
   curatorName?: string;
   initialFollowers: number;
+  initiallyFollowing: boolean;
   requiresAuth: boolean;
+  followRequiresAuth: boolean;
 };
 
 export default function SocialActions({
@@ -21,13 +24,16 @@ export default function SocialActions({
   initialBookmarks,
   initiallyLiked,
   initiallyBookmarked,
+  curatorHandle,
   curatorName,
   initialFollowers,
+  initiallyFollowing,
   requiresAuth,
+  followRequiresAuth,
 }: Props) {
   const [liked, setLiked] = useState(initiallyLiked);
   const [bookmarked, setBookmarked] = useState(initiallyBookmarked);
-  const [followed, setFollowed] = useState(false);
+  const [followed, setFollowed] = useState(initiallyFollowing);
   const [pending, startTransition] = useTransition();
   const [status, setStatus] = useState<string | null>(null);
 
@@ -36,7 +42,10 @@ export default function SocialActions({
     () => initialBookmarks + (bookmarked ? 1 : 0) - (initiallyBookmarked ? 1 : 0),
     [initialBookmarks, bookmarked, initiallyBookmarked],
   );
-  const followers = useMemo(() => initialFollowers + (followed ? 1 : 0), [initialFollowers, followed]);
+  const followers = useMemo(
+    () => initialFollowers + (followed ? 1 : 0) - (initiallyFollowing ? 1 : 0),
+    [initialFollowers, followed, initiallyFollowing],
+  );
 
   const handleLike = () => {
     startTransition(async () => {
@@ -68,11 +77,28 @@ export default function SocialActions({
     });
   };
 
+  const handleFollow = () => {
+    if (!curatorHandle) return;
+
+    startTransition(async () => {
+      const previous = followed;
+      setStatus(null);
+      setFollowed(!previous);
+      const result = await toggleCuratorFollow(curatorHandle);
+      if (!result.success) {
+        setFollowed(previous);
+        setStatus(result.error ?? "팔로우 상태를 저장하지 못했어요.");
+        return;
+      }
+      setFollowed(Boolean(result.followed));
+    });
+  };
+
   return (
     <div className="terminal-frame p-4">
       <p className="text-sm font-semibold">가벼운 액션</p>
       <p className="mt-2 text-xs leading-6 text-[var(--terminal-muted)]">
-        이제 좋아요와 북마크는 로그인한 사용자 기준으로 실제 저장돼요. 팔로우는 아직 다음 단계에서 이어집니다.
+        좋아요, 북마크, 팔로우가 모두 로그인한 사용자 기준으로 실제 저장돼요.
       </p>
 
       {requiresAuth && (
@@ -100,14 +126,22 @@ export default function SocialActions({
           <span>{bookmarked ? "북마크 해제" : "북마크"}</span>
           <span>{bookmarks}</span>
         </button>
-        <button
-          type="button"
-          className="terminal-button w-full justify-between"
-          onClick={() => setFollowed((value) => !value)}
-        >
-          <span>{followed ? `${curatorName ?? "큐레이터"} 언팔로우` : `${curatorName ?? "큐레이터"} 팔로우`}</span>
-          <span>{followers}</span>
-        </button>
+        {followRequiresAuth ? (
+          <Link href="/auth" className="terminal-button w-full justify-between">
+            <span>{curatorName ?? "큐레이터"} 팔로우</span>
+            <span>{followers}</span>
+          </Link>
+        ) : (
+          <button
+            type="button"
+            className="terminal-button w-full justify-between"
+            onClick={handleFollow}
+            disabled={pending || !curatorHandle}
+          >
+            <span>{followed ? `${curatorName ?? "큐레이터"} 언팔로우` : `${curatorName ?? "큐레이터"} 팔로우`}</span>
+            <span>{followers}</span>
+          </button>
+        )}
       </div>
 
       {status && <p className="mt-3 text-xs leading-6 text-[var(--terminal-soft)]">{status}</p>}

--- a/src/app/decks/[slug]/page.tsx
+++ b/src/app/decks/[slug]/page.tsx
@@ -77,7 +77,9 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
   const relatedDecks = getRelatedDecks(deck, allDecks);
   const relatedCards = cards.length > 0 ? getRelatedCards(cards[0], allCards) : [];
   const social = await getDeckSocialMeta(deck.slug);
-  const profileSocial = deck.authorHandle ? getProfileSocialMeta(deck.authorHandle) : { followers: 0 };
+  const profileSocial = deck.authorHandle
+    ? await getProfileSocialMeta(deck.authorHandle)
+    : { followers: 0, viewerIsFollowing: false, requiresAuth: true };
 
   return (
     <div className="min-h-screen text-white">
@@ -208,9 +210,12 @@ export default async function DeckDetailPage({ params, searchParams }: Props) {
               initialBookmarks={social.bookmarks}
               initiallyLiked={social.viewerHasLiked}
               initiallyBookmarked={social.viewerHasBookmarked}
+              curatorHandle={deck.authorHandle}
               curatorName={deck.authorName}
               initialFollowers={profileSocial.followers}
+              initiallyFollowing={profileSocial.viewerIsFollowing}
               requiresAuth={social.requiresAuth}
+              followRequiresAuth={profileSocial.requiresAuth}
             />
           </div>
         </section>

--- a/src/app/users/[handle]/FollowCuratorButton.tsx
+++ b/src/app/users/[handle]/FollowCuratorButton.tsx
@@ -1,22 +1,54 @@
 "use client";
 
-import { useState } from "react";
+import Link from "next/link";
+import { useMemo, useState, useTransition } from "react";
+import { toggleCuratorFollow } from "@/lib/actions/social";
 
 type Props = {
+  handle: string;
   name: string;
   initialFollowers: number;
+  initiallyFollowing: boolean;
+  requiresAuth: boolean;
 };
 
-export default function FollowCuratorButton({ name, initialFollowers }: Props) {
-  const [followed, setFollowed] = useState(false);
-  const followers = initialFollowers + (followed ? 1 : 0);
+export default function FollowCuratorButton({ handle, name, initialFollowers, initiallyFollowing, requiresAuth }: Props) {
+  const [followed, setFollowed] = useState(initiallyFollowing);
+  const [pending, startTransition] = useTransition();
+  const [status, setStatus] = useState<string | null>(null);
+  const followers = useMemo(
+    () => initialFollowers + (followed ? 1 : 0) - (initiallyFollowing ? 1 : 0),
+    [initialFollowers, followed, initiallyFollowing],
+  );
+
+  const handleToggle = () => {
+    startTransition(async () => {
+      const previous = followed;
+      setStatus(null);
+      setFollowed(!previous);
+      const result = await toggleCuratorFollow(handle);
+      if (!result.success) {
+        setFollowed(previous);
+        setStatus(result.error ?? "팔로우 상태를 저장하지 못했어요.");
+        return;
+      }
+      setFollowed(Boolean(result.followed));
+    });
+  };
 
   return (
     <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
-      <button type="button" className="terminal-button w-full sm:w-auto" onClick={() => setFollowed((value) => !value)}>
-        {followed ? `${name} 언팔로우` : `${name} 팔로우`}
-      </button>
+      {requiresAuth ? (
+        <div className="w-full border border-[var(--terminal-border)] px-3 py-3 text-xs leading-6 text-[var(--terminal-soft)] sm:w-auto">
+          팔로우를 저장하려면 먼저 로그인해 주세요. <Link href="/auth" className="underline underline-offset-4">로그인하러 가기 →</Link>
+        </div>
+      ) : (
+        <button type="button" className="terminal-button w-full sm:w-auto" onClick={handleToggle} disabled={pending}>
+          {followed ? `${name} 언팔로우` : `${name} 팔로우`}
+        </button>
+      )}
       <span className="text-sm text-[var(--terminal-muted)]">팔로워 {followers}</span>
+      {status && <p className="w-full text-xs leading-6 text-[var(--terminal-soft)]">{status}</p>}
     </div>
   );
 }

--- a/src/app/users/[handle]/page.tsx
+++ b/src/app/users/[handle]/page.tsx
@@ -16,10 +16,9 @@ export default async function UserProfilePage({ params }: Props) {
 
   if (!profile) notFound();
 
-  const [cards, decks] = await Promise.all([listCards(), listDecks()]);
+  const [cards, decks, social] = await Promise.all([listCards(), listDecks(), getProfileSocialMeta(handle)]);
   const authoredCards = cards.filter((card) => card.authorHandle === handle);
   const authoredDecks = decks.filter((deck) => deck.authorHandle === handle);
-  const social = getProfileSocialMeta(handle);
 
   return (
     <div className="min-h-screen text-white">
@@ -39,7 +38,13 @@ export default async function UserProfilePage({ params }: Props) {
                 <span>{authoredDecks.length} decks</span>
                 <span>{social.followers} followers</span>
               </div>
-              <FollowCuratorButton name={profile.name} initialFollowers={social.followers} />
+              <FollowCuratorButton
+                handle={profile.handle}
+                name={profile.name}
+                initialFollowers={social.followers}
+                initiallyFollowing={social.viewerIsFollowing}
+                requiresAuth={social.requiresAuth}
+              />
             </div>
 
             <aside className="terminal-frame p-4">

--- a/src/lib/actions/social.ts
+++ b/src/lib/actions/social.ts
@@ -4,12 +4,22 @@ import { revalidatePath } from "next/cache";
 import { requireCurrentAuthoredProfile } from "@/lib/authored-content";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
-async function requireDeckId(slug: string) {
+async function requireSupabase(): Promise<{ supabase: NonNullable<Awaited<ReturnType<typeof createSupabaseServerClient>>> } | { error: string }> {
   const supabase = await createSupabaseServerClient();
   if (!supabase) {
     return { error: "Supabase가 아직 연결되지 않았어요. 반응 저장은 잠시 후 다시 시도해 주세요." } as const;
   }
 
+  return { supabase } as const;
+}
+
+async function requireDeckId(slug: string): Promise<{ supabase: NonNullable<Awaited<ReturnType<typeof createSupabaseServerClient>>>; deckId: string } | { error: string }> {
+  const resolved = await requireSupabase();
+  if ("error" in resolved) {
+    return resolved;
+  }
+
+  const { supabase } = resolved;
   const { data: deck, error } = await (supabase.from("decks") as any).select("id").eq("slug", slug).maybeSingle();
 
   if (error || !deck) {
@@ -89,4 +99,49 @@ export async function toggleDeckBookmark(slug: string) {
 
   revalidatePath(`/decks/${slug}`);
   return { success: true, bookmarked: true };
+}
+
+export async function toggleCuratorFollow(handle: string) {
+  const authored = await requireCurrentAuthoredProfile();
+  if ("error" in authored) {
+    return { success: false, error: authored.error };
+  }
+
+  const normalizedHandle = handle.trim().toLowerCase();
+  if (!normalizedHandle) {
+    return { success: false, error: "대상 큐레이터를 찾지 못했어요." };
+  }
+
+  if (normalizedHandle === authored.identity.handle) {
+    return { success: false, error: "자기 자신은 팔로우할 수 없어요." };
+  }
+
+  const resolved = await requireSupabase();
+  if ("error" in resolved) {
+    return { success: false, error: resolved.error };
+  }
+
+  const { supabase } = resolved;
+  const { data: existing } = await (supabase.from("curator_follows") as any)
+    .select("id")
+    .eq("curator_handle", normalizedHandle)
+    .eq("user_id", authored.identity.userId)
+    .maybeSingle();
+
+  if (existing) {
+    const { error } = await (supabase.from("curator_follows") as any).delete().eq("id", existing.id);
+    if (error) return { success: false, error: error.message };
+    revalidatePath(`/users/${normalizedHandle}`);
+    return { success: true, followed: false };
+  }
+
+  const { error } = await (supabase.from("curator_follows") as any).insert({
+    curator_handle: normalizedHandle,
+    user_id: authored.identity.userId,
+  });
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/users/${normalizedHandle}`);
+  return { success: true, followed: true };
 }

--- a/src/lib/social.ts
+++ b/src/lib/social.ts
@@ -11,6 +11,8 @@ export type DeckSocialMeta = {
 
 export type ProfileSocialMeta = {
   followers: number;
+  viewerIsFollowing: boolean;
+  requiresAuth: boolean;
 };
 
 const deckSocialSeed: Record<string, { likes: number; bookmarks: number }> = {
@@ -21,7 +23,7 @@ const deckSocialSeed: Record<string, { likes: number; bookmarks: number }> = {
   "emotion-arc": { likes: 54, bookmarks: 22 },
 };
 
-const profileSocialSeed: Record<string, ProfileSocialMeta> = {
+const profileSocialSeed: Record<string, { followers: number }> = {
   bini59: { followers: 142 },
   miku: { followers: 256 },
 };
@@ -30,8 +32,33 @@ export const getDeckSeedSocialMeta = (slug: string) => {
   return deckSocialSeed[slug] ?? { likes: 0, bookmarks: 0 };
 };
 
-export const getProfileSocialMeta = (handle: string): ProfileSocialMeta => {
+export const getProfileSeedSocialMeta = (handle: string) => {
   return profileSocialSeed[handle] ?? { followers: 0 };
+};
+
+export const getProfileSocialMeta = async (handle: string): Promise<ProfileSocialMeta> => {
+  const normalizedHandle = handle.trim().toLowerCase();
+  const seed = getProfileSeedSocialMeta(normalizedHandle);
+  const supabase = await createSupabaseServerClient();
+  const user = await getCurrentUser();
+
+  if (!supabase) {
+    return {
+      followers: seed.followers,
+      viewerIsFollowing: false,
+      requiresAuth: true,
+    };
+  }
+
+  const { data: follows } = await (supabase.from("curator_follows") as any)
+    .select("user_id")
+    .eq("curator_handle", normalizedHandle);
+
+  return {
+    followers: follows?.length ?? seed.followers,
+    viewerIsFollowing: Boolean(user && follows?.some((entry: { user_id: string }) => entry.user_id === user.id)),
+    requiresAuth: !user,
+  };
 };
 
 export const getDeckSocialMeta = async (slug: string): Promise<DeckSocialMeta> => {

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -157,6 +157,26 @@ export interface Database {
           created_at?: string
         }
       }
+      curator_follows: {
+        Row: {
+          id: string
+          curator_handle: string
+          user_id: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          curator_handle: string
+          user_id: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          curator_handle?: string
+          user_id?: string
+          created_at?: string
+        }
+      }
     }
     Views: {
       [_ in never]: never

--- a/supabase/migrations/005_curator_follows.sql
+++ b/supabase/migrations/005_curator_follows.sql
@@ -1,0 +1,21 @@
+create table if not exists public.curator_follows (
+  id uuid primary key default gen_random_uuid(),
+  curator_handle text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique(curator_handle, user_id)
+);
+
+create index if not exists curator_follows_curator_handle_idx on public.curator_follows(curator_handle);
+create index if not exists curator_follows_user_id_idx on public.curator_follows(user_id);
+
+alter table public.curator_follows enable row level security;
+
+create policy "Allow public read access on curator_follows" on public.curator_follows
+  for select using (true);
+
+create policy "Allow authenticated users to follow curators" on public.curator_follows
+  for insert to authenticated with check (auth.uid() = user_id);
+
+create policy "Allow authenticated users to unfollow curators" on public.curator_follows
+  for delete to authenticated using (auth.uid() = user_id);


### PR DESCRIPTION
## 🎵 변경 사항\n- add Supabase-backed curator follow persistence keyed by curator handle\n- surface viewer-specific follow state on profile and deck detail pages\n- add logged-out auth CTA and tests for follow actions\n\n## 🎤 동기 / 맥락\n- closes #53\n\n## 🎹 테스트\n- [x] pnpm typecheck\n- [x] pnpm test\n\n## ✅ 체크리스트\n- [x] self-review 완료\n- [x] 문서 업데이트 불필요\n- [x] 파괴적 변경 없음